### PR TITLE
Find composer when not globally installed

### DIFF
--- a/src/Checks/ComposerIsUpToDate.php
+++ b/src/Checks/ComposerIsUpToDate.php
@@ -15,6 +15,7 @@ class ComposerIsUpToDate implements Check
     public function __construct(Composer $composer)
     {
         $this->composer = $composer;
+        $this->composer->setWorkingPath(base_path());
     }
 
     /**


### PR DESCRIPTION
I am one of those strange people that has `composer.phar` in the root of my project instead of relying upon composer being globally installed. `Illuminate\Support\Composer` has support for this in `findComposer()` but it needs to know the workingDirectory. I am not sure how you feel about calling functions like `base_path()` in your code but this did fix the issue for me