### PR TITLE
Make the paths to check configurable

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -46,4 +46,12 @@ return [
         \BeyondCode\SelfDiagnosis\Checks\Development\RoutesAreNotCached::class,
     ],
 
+
+    /*
+     * The paths to check for the correct permissions
+     */
+    'directoryPaths' => [
+        storage_path(),
+        base_path('bootstrap/cache'),
+    ],
 ];

--- a/src/Checks/DirectoriesHaveCorrectPermissions.php
+++ b/src/Checks/DirectoriesHaveCorrectPermissions.php
@@ -49,10 +49,10 @@ class DirectoriesHaveCorrectPermissions implements Check
      */
     public function check(): bool
     {
-        $this->paths = Collection::make([
+        $this->paths = Collection::make(config('self-diagnosis.directoryPaths', [
             storage_path(),
-            base_path('bootstrap/cache')
-        ]);
+            base_path('bootstrap/cache'),
+        ]));
 
         $this->paths = $this->paths->reject(function ($path) {
             return $this->filesystem->isWritable($path);


### PR DESCRIPTION
This makes it possible to configure the paths that need to be checked with the DirectoriesHaveCorrectPermissions check.