### PR TITLE
Make texts translateable

### DIFF
--- a/src/Checks/AppKeyIsSet.php
+++ b/src/Checks/AppKeyIsSet.php
@@ -11,7 +11,7 @@ class AppKeyIsSet implements Check
      */
     public function name(): string
     {
-        return 'App key is set';
+        return trans('self-diagnosis::checks.app_key_is_set.name');
     }
 
     /**
@@ -31,6 +31,6 @@ class AppKeyIsSet implements Check
      */
     public function message() : string
     {
-        return 'The application key is not set. Call "php artisan key:generate" to create it.';
+        return trans('self-diagnosis::checks.app_key_is_set.message');
     }
 }

--- a/src/Checks/CorrectPhpVersionIsInstalled.php
+++ b/src/Checks/CorrectPhpVersionIsInstalled.php
@@ -21,7 +21,7 @@ class CorrectPhpVersionIsInstalled implements Check
      */
     public function name(): string
     {
-        return 'The correct PHP version is installed';
+        return trans('self-diagnosis::checks.correct_php_version_is_installed.name');
     }
 
     /**
@@ -43,7 +43,10 @@ class CorrectPhpVersionIsInstalled implements Check
      */
     public function message() : string
     {
-        return 'You do not have the required PHP version installed.'.PHP_EOL.'Required: '.$this->getRequiredPhpVersion().PHP_EOL.'Used: '.phpversion();
+        return trans('self-diagnosis::checks.correct_php_version_is_installed.message', [
+            'required' => $this->getRequiredPhpVersion(),
+            'used' => phpversion(),
+        ]);
     }
 
     /**

--- a/src/Checks/DatabaseCanBeAccessed.php
+++ b/src/Checks/DatabaseCanBeAccessed.php
@@ -15,7 +15,7 @@ class DatabaseCanBeAccessed implements Check
      */
     public function name(): string
     {
-        return 'The database can be accessed';
+        return trans('self-diagnosis::checks.database_can_be_accessed.name');
     }
 
     /**
@@ -42,6 +42,8 @@ class DatabaseCanBeAccessed implements Check
      */
     public function message() : string
     {
-        return 'The database can not be accessed: '.$this->message;
+        return trans('self-diagnosis::checks.database_can_be_accessed.message', [
+            'error' => $this->message,
+        ]);
     }
 }

--- a/src/Checks/Development/ComposerWithDevDependenciesIsUpToDate.php
+++ b/src/Checks/Development/ComposerWithDevDependenciesIsUpToDate.php
@@ -26,7 +26,7 @@ class ComposerWithDevDependenciesIsUpToDate implements Check
      */
     public function name(): string
     {
-        return 'Composer dependencies are up to date with the composer.lock file.';
+        return trans('self-diagnosis::checks.composer_with_dev_dependencies_is_up_to_date.name');
     }
 
     /**
@@ -48,6 +48,8 @@ class ComposerWithDevDependenciesIsUpToDate implements Check
      */
     public function message() : string
     {
-        return 'Your composer dependencies are not up to date. Call "composer install".' . $this->output;
+        return trans('self-diagnosis::checks.composer_with_dev_dependencies_is_up_to_date.message', [
+            'more' => $this->output,
+        ]);
     }
 }

--- a/src/Checks/Development/ConfigurationIsNotCached.php
+++ b/src/Checks/Development/ConfigurationIsNotCached.php
@@ -14,7 +14,7 @@ class ConfigurationIsNotCached implements Check
      */
     public function name(): string
     {
-        return 'Configuration is not cached';
+        return trans('self-diagnosis::checks.configuration_is_not_cached.name');
     }
 
     /**
@@ -34,6 +34,6 @@ class ConfigurationIsNotCached implements Check
      */
     public function message(): string
     {
-        return 'Your configuration files should not be cached during development. Call "php artisan config:clear" to clear the config cache.';
+        return trans('self-diagnosis::checks.configuration_is_not_cached.message');
     }
 }

--- a/src/Checks/Development/RoutesAreNotCached.php
+++ b/src/Checks/Development/RoutesAreNotCached.php
@@ -14,7 +14,7 @@ class RoutesAreNotCached implements Check
      */
     public function name(): string
     {
-        return 'Routes are not cached';
+        return trans('self-diagnosis::checks.routes_are_not_cached.name');
     }
 
     /**
@@ -34,6 +34,6 @@ class RoutesAreNotCached implements Check
      */
     public function message(): string
     {
-        return 'Your routes should not be cached during development. Call "php artisan route:clear" to clear the route cache.';
+        return trans('self-diagnosis::checks.routes_are_not_cached.message');
     }
 }

--- a/src/Checks/DirectoriesHaveCorrectPermissions.php
+++ b/src/Checks/DirectoriesHaveCorrectPermissions.php
@@ -29,7 +29,7 @@ class DirectoriesHaveCorrectPermissions implements Check
      */
     public function name(): string
     {
-        return 'The directories have the correct permissions.';
+        return trans('self-diagnosis::checks.directories_have_correct_permissions.name');
     }
 
     /**
@@ -39,7 +39,9 @@ class DirectoriesHaveCorrectPermissions implements Check
      */
     public function message() : string
     {
-        return 'The following directories are not writable: '.PHP_EOL.$this->paths->implode(PHP_EOL);
+        return trans('self-diagnosis::checks.directories_have_correct_permissions.message', [
+            'directories' => $this->paths->implode(PHP_EOL),
+        ]);
     }
 
     /**

--- a/src/Checks/EnvFileExists.php
+++ b/src/Checks/EnvFileExists.php
@@ -22,7 +22,7 @@ class EnvFileExists implements Check
      */
     public function name(): string
     {
-        return 'The environment file exists';
+        return trans('self-diagnosis::checks.env_file_exists.name');
     }
 
     /**
@@ -42,6 +42,6 @@ class EnvFileExists implements Check
      */
     public function message() : string
     {
-        return 'These .env file does not exist. Please copy your .env.example file as .env';
+        return trans('self-diagnosis::checks.env_file_exists.message');
     }
 }

--- a/src/Checks/ExampleEnvironmentVariablesAreSet.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreSet.php
@@ -18,7 +18,7 @@ class ExampleEnvironmentVariablesAreSet implements Check
      */
     public function name(): string
     {
-        return 'The example environment variables are set';
+        return trans('self-diagnosis::checks.example_environment_variables_are_set.name');
     }
 
     /**
@@ -47,6 +47,8 @@ class ExampleEnvironmentVariablesAreSet implements Check
      */
     public function message() : string
     {
-        return 'These example environment variables are missing in your .env file, but are defined in your .env.example: '.PHP_EOL.$this->envVariables->implode(PHP_EOL);
+        return trans('self-diagnosis::checks.example_environment_variables_are_set.message', [
+            'variables' => $this->envVariables->implode(PHP_EOL),
+        ]);
     }
 }

--- a/src/Checks/MigrationsAreUpToDate.php
+++ b/src/Checks/MigrationsAreUpToDate.php
@@ -15,7 +15,7 @@ class MigrationsAreUpToDate implements Check
      */
     public function name(): string
     {
-        return 'The migrations are up to date';
+        return trans('self-diagnosis::checks.migrations_are_up_to_date.name');
     }
 
     /**
@@ -43,8 +43,10 @@ class MigrationsAreUpToDate implements Check
     public function message(): string
     {
         if ($this->databaseError !== null) {
-            return 'Unable to check for migrations: ' . $this->databaseError;
+            return trans('self-diagnosis::checks.migrations_are_up_to_date.message.unable_to_check', [
+                'reason' => $this->databaseError,
+            ]);
         }
-        return 'You need to update your migrations. Call "php artisan migrate".';
+        return trans('self-diagnosis::checks.migrations_are_up_to_date.message.need_to_migrate');
     }
 }

--- a/src/Checks/PhpExtensionsAreInstalled.php
+++ b/src/Checks/PhpExtensionsAreInstalled.php
@@ -28,7 +28,7 @@ class PhpExtensionsAreInstalled implements Check
      */
     public function name(): string
     {
-        return 'The required PHP extensions are installed';
+        return trans('self-dianosis::checks.php_extensions_are_installed.name');
     }
 
     /**
@@ -38,7 +38,9 @@ class PhpExtensionsAreInstalled implements Check
      */
     public function message(): string
     {
-        return 'The following extensions are missing: ' . PHP_EOL . $this->extensions->implode(PHP_EOL);
+        return trans('self-dianosis::checks.php_extensions_are_installed.message', [
+            'extensions' => $this->extensions->implode(PHP_EOL),
+        ]);
     }
 
     /**

--- a/src/Checks/Production/ComposerWithoutDevDependenciesIsUpToDate.php
+++ b/src/Checks/Production/ComposerWithoutDevDependenciesIsUpToDate.php
@@ -26,7 +26,7 @@ class ComposerWithoutDevDependenciesIsUpToDate implements Check
      */
     public function name(): string
     {
-        return 'Composer dependencies (without dev) are up to date with the composer.lock file.';
+        return trans('self-diagnosis::checks.composer_without_dev_dependencies_is_up_to_date.name');
     }
 
     /**
@@ -48,6 +48,8 @@ class ComposerWithoutDevDependenciesIsUpToDate implements Check
      */
     public function message() : string
     {
-        return 'Your composer dependencies are not up to date. Call "composer install".' . $this->output;
+        return trans('self-diagnosis::checks.composer_without_dev_dependencies_is_up_to_date.message', [
+            'more' => $this->output,
+        ]);
     }
 }

--- a/src/Checks/Production/ConfigurationIsCached.php
+++ b/src/Checks/Production/ConfigurationIsCached.php
@@ -14,7 +14,7 @@ class ConfigurationIsCached implements Check
      */
     public function name(): string
     {
-        return 'Configuration is cached';
+        return trans('self-diagnosis::checks.configuration_is_cached.name');
     }
 
     /**
@@ -34,6 +34,6 @@ class ConfigurationIsCached implements Check
      */
     public function message(): string
     {
-        return 'Your configuration files should be cached in production. Call "php artisan config:cache" to cache the configuration.';
+        return trans('self-diagnosis::checks.configuration_is_cached.message');
     }
 }

--- a/src/Checks/Production/DebugModeIsNotEnabled.php
+++ b/src/Checks/Production/DebugModeIsNotEnabled.php
@@ -14,7 +14,7 @@ class DebugModeIsNotEnabled implements Check
      */
     public function name(): string
     {
-        return 'Debug mode is not enabled';
+        return trans('self-diagnosis::checks.debug_mode_is_not_enabled.name');
     }
 
     /**
@@ -34,6 +34,6 @@ class DebugModeIsNotEnabled implements Check
      */
     public function message(): string
     {
-        return 'You should not use debug mode in production. Set APP_DEBUG to false.';
+        return trans('self-diagnosis::checks.debug_mode_is_not_enabled.message');
     }
 }

--- a/src/Checks/Production/RoutesAreCached.php
+++ b/src/Checks/Production/RoutesAreCached.php
@@ -14,7 +14,7 @@ class RoutesAreCached implements Check
      */
     public function name(): string
     {
-        return 'Routes are cached';
+        return trans('self-diagnosis::checks.routes_are_cached.name');
     }
 
     /**
@@ -34,6 +34,6 @@ class RoutesAreCached implements Check
      */
     public function message(): string
     {
-        return 'Your routes should be cached in production. Call "php artisan route:cache" to create the route cache.';
+        return trans('self-diagnosis::checks.routes_are_cached.message');
     }
 }

--- a/src/Checks/Production/XDebugIsNotEnabled.php
+++ b/src/Checks/Production/XDebugIsNotEnabled.php
@@ -14,7 +14,7 @@ class XDebugIsNotEnabled implements Check
      */
     public function name(): string
     {
-        return 'The xdebug extension is not active.';
+        return trans('self-diagnosis::checks.xdebug_is_not_enabled.name');
     }
 
     /**
@@ -34,6 +34,6 @@ class XDebugIsNotEnabled implements Check
      */
     public function message(): string
     {
-        return 'You should not have the "xdebug" PHP extension activated in production.';
+        return trans('self-diagnosis::checks.xdebug_is_not_enabled.message');
     }
 }

--- a/src/Checks/StorageDirectoryIsLinked.php
+++ b/src/Checks/StorageDirectoryIsLinked.php
@@ -21,7 +21,7 @@ class StorageDirectoryIsLinked implements Check
      */
     public function name(): string
     {
-        return 'The storage directory is linked.';
+        return trans('self-diagnosis::checks.storage_directory_is_linked.name');
     }
 
     /**
@@ -31,7 +31,7 @@ class StorageDirectoryIsLinked implements Check
      */
     public function message() : string
     {
-        return 'The storage directory is not linked. Use "php artisan storage:link"';
+        return trans('self-diagnosis::checks.storage_directory_is_linked.message');
     }
 
     /**

--- a/src/SelfDiagnosisCommand.php
+++ b/src/SelfDiagnosisCommand.php
@@ -25,24 +25,24 @@ class SelfDiagnosisCommand extends Command
 
     public function handle()
     {
-        $this->runChecks(config('self-diagnosis.checks', []), 'Running Common Checks');
+        $this->runChecks(config('self-diagnosis.checks', []), trans('self-diagnosis::commands.self_diagnosis.common_checks'));
 
         $environmentChecks = config('self-diagnosis.development', []);
         if (in_array(app()->environment(), config('self-diagnosis.productionEnvironments'))) {
             $environmentChecks = config('self-diagnosis.production', []);
         }
 
-        $this->runChecks($environmentChecks, 'Environment Specific Checks ('.app()->environment().')');
+        $this->runChecks($environmentChecks, trans('self-diagnosis::commands.self_diagnosis.environment_specific_checks', ['environment' => app()->environment()]));
 
         if (count($this->messages)) {
-            $this->output->writeln('The following checks failed:');
+            $this->output->writeln(trans('self-diagnosis::commands.self_diagnosis.failed_checks'));
 
             foreach ($this->messages as $message) {
                 $this->output->writeln('<fg=red>'.$message.'</fg=red>');
                 $this->output->writeln('');
             }
         } else {
-            $this->info('Good job, looks like you are all set up.');
+            $this->info(trans('self-diagnosis::commands.self_diagnosis.success'));
         }
     }
 
@@ -58,7 +58,11 @@ class SelfDiagnosisCommand extends Command
         foreach ($checks as $check) {
             $checkClass = app($check);
 
-            $this->output->write("<fg=yellow>Running check {$current}/{$max}:</fg=yellow> {$checkClass->name()}...  ");
+            $this->output->write(trans('self-diagnosis::commands.self_diagnosis.running_check', [
+                'current' => $current,
+                'max' => $max,
+                'name' => $checkClass->name(),
+            ]));
 
             $this->runCheck($checkClass);
 

--- a/src/SelfDiagnosisServiceProvider.php
+++ b/src/SelfDiagnosisServiceProvider.php
@@ -13,6 +13,12 @@ class SelfDiagnosisServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
 
+            $this->loadTranslationsFrom(__DIR__.'/../translations', 'self-diagnosis');
+
+            $this->publishes([
+                __DIR__.'/../translations' => resource_path('lang/vendor/self-diagnosis'),
+            ], 'translations');
+
             $this->publishes([
                 __DIR__.'/../config/config.php' => config_path('self-diagnosis.php'),
             ], 'config');

--- a/tests/ExampleEnvironmentVariablesAreSetTest.php
+++ b/tests/ExampleEnvironmentVariablesAreSetTest.php
@@ -15,6 +15,6 @@ class ExampleEnvironmentVariablesAreSetTest extends TestCase
         $check = new ExampleEnvironmentVariablesAreSet();
 
         $this->assertFalse($check->check());
-        $this->assertSame('These example environment variables are missing in your .env file, but are defined in your .env.example: '.PHP_EOL.'KEY_TWO', $check->message());
+        $this->assertSame('self-diagnosis::checks.example_environment_variables_are_set.message', $check->message());
     }
 }

--- a/translations/de/checks.php
+++ b/translations/de/checks.php
@@ -1,0 +1,75 @@
+<?php
+
+return [
+    'app_key_is_set' => [
+        'message' => 'Der Anwendungsschlüssel ist nicht gesetzt. Nutze "php artisan key:generate", um einen zu erstellen und zu setzen.',
+        'name' => 'Anwendungsschlüssel ist gesetzt',
+    ],
+    'composer_with_dev_dependencies_is_up_to_date' => [
+        'message' => 'Die Composer Abhängigkeiten sind nicht aktuell. Nutze "composer install", um diese zu aktualisieren. :more',
+        'name' => 'Composer Abhängigkeiten (inkl. dev) sind aktuell',
+    ],
+    'composer_without_dev_dependencies_is_up_to_date' => [
+        'message' => 'Die Composer Abhängigkeiten sind nicht aktuell. Nutze "composer install", um diese zu aktualisieren. :more',
+        'name' => 'Composer Abhängigkeiten (ohne dev) sind aktuell',
+    ],
+    'configuration_is_cached' => [
+        'message' => 'Die Konfiguration sollte für bessere Performance gecached sein im Produktivbetrieb. Nutze "php artisan config:cache", um den Konfigurations-Cache zu erstellen.',
+        'name' => 'Konfiguration ist gecached',
+    ],
+    'configuration_is_not_cached' => [
+        'message' => 'Die Konfiguration sollte während der Entwicklung nicht gecached sein. Nutze "php artisan config:clear", um den Konfigurations-Cache zu leeren.',
+        'name' => 'Konfiguration ist nicht gecached',
+    ],
+    'correct_php_version_is_installed' => [
+        'message' => 'Die benötigte PHP Version ist nicht installiert.' . PHP_EOL . 'Benötigt: :required' . PHP_EOL . 'In Verwendung: :used',
+        'name' => 'Die richtige PHP Version ist installiert',
+    ],
+    'database_can_be_accessed' => [
+        'message' => 'Auf die Datenbank kann nicht zugegriffen werden: :error',
+        'name' => 'Die Datenbank ist erreichbar',
+    ],
+    'debug_mode_is_not_enabled' => [
+        'message' => 'Der Debugging-Modus sollte im Produktivbetrieb nicht genutzt werden. Setze "APP_DEBUG" in der .env Datei auf "false".',
+        'name' => 'Der Debugging-Modus ist deaktiviert',
+    ],
+    'directories_have_correct_permissions' => [
+        'message' => 'Folgende Verzeichnisse sind nicht beschreibbar:' . PHP_EOL .':directories',
+        'name' => 'Alle Verzeichnisse haben die richtigen Berechtigungen',
+    ],
+    'env_file_exists' => [
+        'message' => 'Die .env Datei existiert nicht. Bitte kopiere die Datei .env.example zu .env und passe diese entsprechend an.',
+        'name' => 'Die Umgebungsvariablendatei existiert',
+    ],
+    'example_environment_variables_are_set' => [
+        'message' => 'Folgende Umgebungsvariablen fehlen im .env Umgebungsfile, sind aber in .env.example definiert:' . PHP_EOL . ':variables',
+        'name' => 'Die Beispiel-Umgebungsvariablen sind gesetzt',
+    ],
+    'migrations_are_up_to_date' => [
+        'message' => [
+            'need_to_migrate' => 'Die Datenbank muss aktualisiert werden. Nutze "php artisan migrate", um die Migrationen einzuspielen.',
+            'unable_to_check' => 'Die Migrationen konnten nicht geprüft werden: :reason',
+        ],
+        'name' => 'Die Migrationen sind aktuell',
+    ],
+    'php_extensions_are_installed' => [
+        'message' => 'Die folgenden Erweiterungen fehlen:' . PHP_EOL . ':extensions',
+        'name' => 'Die benötigten PHP Erweiterungen sind installiert',
+    ],
+    'routes_are_cached' => [
+        'message' => 'Die Routen sollten für bessere Performance gecached sein im Produktivbetrieb. Nutze "php artisan route:cache", um den Routen-Cache zu erstellen.',
+        'name' => 'Routen sind gecached',
+    ],
+    'routes_are_not_cached' => [
+        'message' => 'Die Routen sollten während der Entwicklung nicht gecached sein. Nutze "php artisan route:clear", um den Routen-Cache zu leeren.',
+        'name' => 'Routen sind nicht gecached',
+    ],
+    'storage_directory_is_linked' => [
+        'message' => 'Das Speicherverzeichnis ist nicht verlinkt. Nutze "php artisan storage:link", um eine symbolische Verknüpfung zu erstellen.',
+        'name' => 'Das Speicherverzeichnis ist verlinkt',
+    ],
+    'xdebug_is_not_enabled' => [
+        'message' => 'Die "xdebug" PHP Erweiterung sollte im Produktivbetrieb nicht aktiviert sein.',
+        'name' => 'Die xdebug PHP Erweiterung ist deaktiviert',
+    ],
+];

--- a/translations/de/commands.php
+++ b/translations/de/commands.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'self_diagnosis' => [
+        'common_checks' => 'Allgemeine Überprüfungen',
+        'environment_specific_checks' => 'Umgebungsspezifische Überprüfungen (:environment)',
+        'failed_checks' => 'Folgende Überprüfungen sind fehlgeschlagen:',
+        'running_check' => '<fg=yellow>Überprüfung :current/:max:</fg=yellow> :name...  ',
+        'success' => 'Gute Arbeit, sieht so aus, als wäre alles richtig eingestellt!',
+    ],
+];

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -6,11 +6,11 @@ return [
         'name' => 'App key is set',
     ],
     'composer_with_dev_dependencies_is_up_to_date' => [
-        'message' => 'Your composer dependencies are not up to date. Call "composer install". :more',
+        'message' => 'Your composer dependencies are not up to date. Call "composer install" to update them. :more',
         'name' => 'Composer dependencies (including dev) are up to date',
     ],
     'composer_without_dev_dependencies_is_up_to_date' => [
-        'message' => 'Your composer dependencies are not up to date. Call "composer install". :more',
+        'message' => 'Your composer dependencies are not up to date. Call "composer install" to update them. :more',
         'name' => 'Composer dependencies (without dev) are up to date',
     ],
     'configuration_is_cached' => [
@@ -30,7 +30,7 @@ return [
         'name' => 'The database can be accessed',
     ],
     'debug_mode_is_not_enabled' => [
-        'message' => 'You should not use debug mode in production. Set APP_DEBUG to false.',
+        'message' => 'You should not use debug mode in production. Set "APP_DEBUG" in the .env file to "false".',
         'name' => 'Debug mode is not enabled',
     ],
     'directories_have_correct_permissions' => [
@@ -70,6 +70,6 @@ return [
     ],
     'xdebug_is_not_enabled' => [
         'message' => 'You should not have the "xdebug" PHP extension enabled in production.',
-        'name' => 'The xdebug extension is not enabled',
+        'name' => 'The xdebug extension is disabled',
     ],
 ];

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -1,0 +1,75 @@
+<?php
+
+return [
+    'app_key_is_set' => [
+        'message' => 'The application key is not set. Call "php artisan key:generate" to create and set one.',
+        'name' => 'App key is set',
+    ],
+    'composer_with_dev_dependencies_is_up_to_date' => [
+        'message' => 'Your composer dependencies are not up to date. Call "composer install". :more',
+        'name' => 'Composer dependencies (including dev) are up to date',
+    ],
+    'composer_without_dev_dependencies_is_up_to_date' => [
+        'message' => 'Your composer dependencies are not up to date. Call "composer install". :more',
+        'name' => 'Composer dependencies (without dev) are up to date',
+    ],
+    'configuration_is_cached' => [
+        'message' => 'Your configuration should be cached in production for better performance. Call "php artisan config:cache" to create the configuration cache.',
+        'name' => 'Configuration is cached',
+    ],
+    'configuration_is_not_cached' => [
+        'message' => 'Your configuration files should not be cached during development. Call "php artisan config:clear" to clear the configuration cache.',
+        'name' => 'Configuration is not cached',
+    ],
+    'correct_php_version_is_installed' => [
+        'message' => 'You do not have the required PHP version installed.' . PHP_EOL . 'Required: :required' . PHP_EOL . 'Used: :used',
+        'name' => 'The correct PHP version is installed',
+    ],
+    'database_can_be_accessed' => [
+        'message' => 'The database can not be accessed: :error',
+        'name' => 'The database can be accessed',
+    ],
+    'debug_mode_is_not_enabled' => [
+        'message' => 'You should not use debug mode in production. Set APP_DEBUG to false.',
+        'name' => 'Debug mode is not enabled',
+    ],
+    'directories_have_correct_permissions' => [
+        'message' => 'The following directories are not writable:' . PHP_EOL .':directories',
+        'name' => 'All directories have the correct permissions',
+    ],
+    'env_file_exists' => [
+        'message' => 'The .env file does not exist. Please copy your .env.example file as .env and adjust accordingly.',
+        'name' => 'The environment file exists',
+    ],
+    'example_environment_variables_are_set' => [
+        'message' => 'These environment variables are missing in your .env file, but are defined in your .env.example:' . PHP_EOL . ':variables',
+        'name' => 'The example environment variables are set',
+    ],
+    'migrations_are_up_to_date' => [
+        'message' => [
+            'need_to_migrate' => 'You need to update your database. Call "php artisan migrate" to run migrations.',
+            'unable_to_check' => 'Unable to check for migrations: :reason',
+        ],
+        'name' => 'The migrations are up to date',
+    ],
+    'php_extensions_are_installed' => [
+        'message' => 'The following extensions are missing:' . PHP_EOL . ':extensions',
+        'name' => 'The required PHP extensions are installed',
+    ],
+    'routes_are_cached' => [
+        'message' => 'Your routes should be cached in production for better performance. Call "php artisan route:cache" to create the route cache.',
+        'name' => 'Routes are cached',
+    ],
+    'routes_are_not_cached' => [
+        'message' => 'Your routes should not be cached during development. Call "php artisan route:clear" to clear the route cache.',
+        'name' => 'Routes are not cached',
+    ],
+    'storage_directory_is_linked' => [
+        'message' => 'The storage directory is not linked. Use "php artisan storage:link" to create a symbolic link.',
+        'name' => 'The storage directory is linked',
+    ],
+    'xdebug_is_not_enabled' => [
+        'message' => 'You should not have the "xdebug" PHP extension enabled in production.',
+        'name' => 'The xdebug extension is not enabled',
+    ],
+];

--- a/translations/en/commands.php
+++ b/translations/en/commands.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'self_diagnosis' => [
+        'common_checks' => 'Common Checks',
+        'environment_specific_checks' => 'Environment Specific Checks (:environment)',
+        'failed_checks' => 'The following checks failed:',
+        'running_check' => '<fg=yellow>Running check :current/:max:</fg=yellow> :name...  ',
+        'success' => 'Good job, looks like you are all set up!',
+    ],
+];


### PR DESCRIPTION
In reference to #8 I prepared a PR that makes texts translateable. As this is the first time I used translation within a package, I'm not completely convinced I did everything correct, so I would appreciate any reviews. Also, I did not have time to test my changes yet - so please consider it as WIP.

What has been changed:
- Checks and the currently only command do now make use of translations for texts (used `trans()` in favour of `__()`... if that is not good, please tell me).
- Streamlined some texts slightly (removed trailing dot `.` from some command names and removed the `composer.lock` part from the `composer install` checks because the `.lock` file does not necessarily have to exist)