### PR TITLE
Add new check called LocalesAreInstalled

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ return [
         ],
         \BeyondCode\SelfDiagnosis\Checks\EnvFileExists::class,
         \BeyondCode\SelfDiagnosis\Checks\ExampleEnvironmentVariablesAreSet::class,
+        \BeyondCode\SelfDiagnosis\Checks\LocalesAreInstalled::class => [
+            'required_locales' => [
+                'en_US',
+                'en_US.utf8',
+            ],
+        ],
         \BeyondCode\SelfDiagnosis\Checks\MigrationsAreUpToDate::class,
         \BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreInstalled::class => [
             'extensions' => [
@@ -146,6 +152,8 @@ The following options are available for the individual checks:
   - **connections** *(array, list of connection names like `['mysql', 'sqlsrv']`, default: `[]`)*: additional connections to check
 - [`BeyondCode\SelfDiagnosis\Checks\DirectoriesHaveCorrectPermissions`](src/Checks/DirectoriesHaveCorrectPermissions.php)
   - **directories** *(array, list of directory paths like `[storage_path(), base_path('bootstrap/cache')]`, default: `[]`)*: directories to check
+- [`BeyondCode\SelfDiagnosis\Checks\LocalesAreInstalled`](src/Checks/LocalesAreInstalled.php)
+  - **required_locales** *(array, list of locales like `['en_US', 'en_US.utf8']`, default: `[]`)*: locales to check
 - [`BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreDisabled`](src/Checks/PhpExtensionsAreDisabled.php)
   - **extensions** *(array, list of extension names like `['xdebug', 'zlib']`, default: `[]`)*: extensions to check
 - [`BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreInstalled`](src/Checks/PhpExtensionsAreInstalled.php)

--- a/config/config.php
+++ b/config/config.php
@@ -29,6 +29,12 @@ return [
         ],
         \BeyondCode\SelfDiagnosis\Checks\EnvFileExists::class,
         \BeyondCode\SelfDiagnosis\Checks\ExampleEnvironmentVariablesAreSet::class,
+        \BeyondCode\SelfDiagnosis\Checks\LocalesAreInstalled::class => [
+            'required_locales' => [
+                'en_US',
+                'en_US.utf8',
+            ],
+        ],
         \BeyondCode\SelfDiagnosis\Checks\MigrationsAreUpToDate::class,
         \BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreInstalled::class => [
             'extensions' => [

--- a/src/Checks/LocalesAreInstalled.php
+++ b/src/Checks/LocalesAreInstalled.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Checks;
+
+use BeyondCode\SelfDiagnosis\SystemFunctions;
+use Illuminate\Support\Collection;
+
+class LocalesAreInstalled implements Check
+{
+    /** @var Collection */
+    protected $missingLocales;
+
+    /** @var string|null */
+    protected $message;
+
+    /** @var SystemFunctions */
+    protected $systemFunctions;
+
+    /**
+     * LocalesAreInstalled constructor.
+     *
+     * @param SystemFunctions $systemFunctions
+     */
+    public function __construct(SystemFunctions $systemFunctions)
+    {
+        $this->systemFunctions = $systemFunctions;
+    }
+
+    /**
+     * The name of the check.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function name(array $config): string
+    {
+        return trans('self-diagnosis::checks.locales_are_installed.name');
+    }
+
+    /**
+     * Perform the actual verification of this check.
+     *
+     * @param array $config
+     * @return bool
+     */
+    public function check(array $config): bool
+    {
+        $this->missingLocales = new Collection(array_get($config, 'required_locales', []));
+        if ($this->missingLocales->isEmpty()) {
+            return true;
+        }
+
+        if (!$this->systemFunctions->isFunctionAvailable('shell_exec')) {
+            $this->message = trans('self-diagnosis::checks.locales_are_installed.message.shell_exec_not_available');
+            return false;
+        }
+
+        if ($this->systemFunctions->isWindowsOperatingSystem()) {
+            $this->message = trans('self-diagnosis::checks.locales_are_installed.message.cannot_run_on_windows');
+            return false;
+        }
+
+        $locales = $this->systemFunctions->callShellExec('locale -a');
+        if ($locales === null || $locales === '') {
+            $this->message = trans('self-diagnosis::checks.locales_are_installed.message.locale_command_not_available');
+            return false;
+        }
+
+        $locales = explode("\n" , $locales);
+
+        $this->missingLocales = $this->missingLocales->reject(function ($loc) use ($locales) {
+            return in_array($loc, $locales);
+        });
+
+        return $this->missingLocales->isEmpty();
+    }
+
+    /**
+     * The error message to display in case the check does not pass.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function message(array $config): string
+    {
+        if ($this->message) {
+            return $this->message;
+        }
+
+        return trans('self-diagnosis::checks.locales_are_installed.message.missing_locales', [
+            'locales' => $this->missingLocales->implode(PHP_EOL),
+        ]);
+    }
+}

--- a/src/SystemFunctions.php
+++ b/src/SystemFunctions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis;
+
+/**
+ * Proxy class for system functions.
+ *
+ * Class SystemFunctions
+ * @package BeyondCode\SelfDiagnosis
+ */
+class SystemFunctions
+{
+    /**
+     * Performs a shell_exec call. Acts as proxy.
+     *
+     * @param string $command
+     * @return null|string
+     */
+    public function callShellExec(string $command): ?string
+    {
+        return shell_exec($command);
+    }
+
+    /**
+     * Checks if a function is defined and not disabled.
+     *
+     * @param string $function
+     * @return bool
+     */
+    public function isFunctionAvailable(string $function): bool
+    {
+        return is_callable($function) && true === stripos(ini_get('disable_functions'), $function);
+    }
+
+    /**
+     * Checks if we are running on a windows operating system.
+     *
+     * @return bool
+     */
+    public function isWindowsOperatingSystem(): bool
+    {
+        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+    }
+}

--- a/tests/ExampleEnvironmentVariablesAreSetTest.php
+++ b/tests/ExampleEnvironmentVariablesAreSetTest.php
@@ -8,7 +8,7 @@ use BeyondCode\SelfDiagnosis\Checks\ExampleEnvironmentVariablesAreSet;
 
 class ExampleEnvironmentVariablesAreSetTest extends TestCase
 {
-    public function getPackageProviders()
+    public function getPackageProviders($app)
     {
         return [
             SelfDiagnosisServiceProvider::class,

--- a/tests/LocalesAreInstalledTest.php
+++ b/tests/LocalesAreInstalledTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Tests;
+
+use BeyondCode\SelfDiagnosis\SelfDiagnosisServiceProvider;
+use BeyondCode\SelfDiagnosis\SystemFunctions;
+use Orchestra\Testbench\TestCase;
+use BeyondCode\SelfDiagnosis\Checks\LocalesAreInstalled;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class LocalesAreInstalledTest extends TestCase
+{
+    public function getPackageProviders($app)
+    {
+        return [
+            SelfDiagnosisServiceProvider::class,
+        ];
+    }
+
+    /** @test */
+    public function it_succeeds_when_no_locales_are_required()
+    {
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+
+        $check = new LocalesAreInstalled($systemFunctionsMock);
+        $result = $check->check([]);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_succeeds_when_all_locales_are_installed()
+    {
+        $config = ['required_locales' => ['en_US', 'en_US.utf8', 'de_DE', 'de_DE.utf8', 'de_AT', 'de_AT.utf8']];
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(false);
+        $systemFunctionsMock->expects($this->once())
+            ->method('callShellExec')
+            ->with('locale -a')
+            ->willReturn("de_AT\nde_AT.utf8\nde_DE\nde_DE.utf8\nen_US\nen_US.utf8");
+
+        $check = new LocalesAreInstalled($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_fails_when_shell_exec_is_not_available()
+    {
+        $config = ['required_locales' => ['en_US', 'en_US.utf8']];
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(false);
+
+        $check = new LocalesAreInstalled($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame('The function "shell_exec" is not defined or disabled, so we cannot check the locales.', $check->message($config));
+    }
+
+    /** @test */
+    public function it_fails_when_run_on_windows()
+    {
+        $config = ['required_locales' => ['en_US', 'en_US.utf8']];
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(true);
+
+        $check = new LocalesAreInstalled($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame('This check cannot be run on Windows.', $check->message($config));
+    }
+
+    /** @test */
+    public function it_fails_when_locale_command_not_available()
+    {
+        $config = ['required_locales' => ['en_US', 'en_US.utf8']];
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(false);
+        $systemFunctionsMock->expects($this->once())
+            ->method('callShellExec')
+            ->with('locale -a')
+            ->willReturn('');
+
+        $check = new LocalesAreInstalled($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame('The "locale -a" command is not available on the current OS.', $check->message($config));
+    }
+
+    /** @test */
+    public function it_fails_when_locales_are_missing()
+    {
+        $config = ['required_locales' => ['en_US', 'en_US.utf8', 'de_DE', 'de_DE.utf8', 'de_AT', 'de_AT.utf8']];
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(false);
+        $systemFunctionsMock->expects($this->once())
+            ->method('callShellExec')
+            ->with('locale -a')
+            ->willReturn("de_DE\nde_DE.utf8\nen_US");
+
+        $check = new LocalesAreInstalled($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame("The following locales are missing:\nen_US.utf8\nde_AT\nde_AT.utf8", $check->message($config));
+    }
+}

--- a/translations/de/checks.php
+++ b/translations/de/checks.php
@@ -45,6 +45,15 @@ return [
         'message' => 'Folgende Umgebungsvariablen fehlen im .env Umgebungsfile, sind aber in .env.example definiert:' . PHP_EOL . ':variables',
         'name' => 'Die Beispiel-Umgebungsvariablen sind gesetzt',
     ],
+    'locales_are_installed' => [
+        'message' => [
+            'cannot_run_on_windows' => 'Dieser Check kann unter Windows nicht ausgeführt werden..',
+            'locale_command_not_available' => 'Der Befehl "locale -a" ist auf dem aktuellen System nicht verfügbar.',
+            'missing_locales' => 'Folgende Sprachumgebungen (locales) fehlen:' . PHP_EOL . ':locales',
+            'shell_exec_not_available' => 'Die Funktion "shell_exec" ist entweder nicht definiert oder deaktiviert, daher können die Sprachumgebungen nicht abgefragt werden.',
+        ],
+        'name' => 'Benötigte Sprachumgebungen sind installiert',
+    ],
     'migrations_are_up_to_date' => [
         'message' => [
             'need_to_migrate' => 'Die Datenbank muss aktualisiert werden. Nutze "php artisan migrate", um die Migrationen einzuspielen.',

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -45,6 +45,15 @@ return [
         'message' => 'These environment variables are missing in your .env file, but are defined in your .env.example:' . PHP_EOL . ':variables',
         'name' => 'The example environment variables are set',
     ],
+    'locales_are_installed' => [
+        'message' => [
+            'cannot_run_on_windows' => 'This check cannot be run on Windows.',
+            'locale_command_not_available' => 'The "locale -a" command is not available on the current OS.',
+            'missing_locales' => 'The following locales are missing:' . PHP_EOL . ':locales',
+            'shell_exec_not_available' => 'The function "shell_exec" is not defined or disabled, so we cannot check the locales.',
+        ],
+        'name' => 'Required locales are installed',
+    ],
     'migrations_are_up_to_date' => [
         'message' => [
             'need_to_migrate' => 'You need to update your database. Call "php artisan migrate" to run migrations.',


### PR DESCRIPTION
This PR adds a new check called `LocalesAreInstalled` which ensures a list of locales are installed on the operating system by using the output of `locale -a`:
```
$ locale -a
de_AT
de_AT.utf8
en_US
en_US.utf8
```
All possible outcomes of the check are covered by tests. I hope the way I implemented the system call is fine for you.