### PR TITLE
Fix composer and command exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-All notable changes to `laravel-self-diagnosis` will be documented in this file
+All notable changes to `laravel-self-diagnosis` will be documented in this file.
 
-## 1.0.0 - 201X-XX-XX
+The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-- initial release
+## 1.5.0 - 2018-XX-XX
+
+### Changed
+
+- DocBlocks updated
+
+[keepachangelog]:https://keepachangelog.com/en/1.0.0/
+[semver]:https://semver.org/spec/v2.0.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - DocBlocks updated
+- If `self-diagnosis` command fails - exit code is greater than `0`
 
 [keepachangelog]:https://keepachangelog.com/en/1.0.0/
 [semver]:https://semver.org/spec/v2.0.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - DocBlocks updated
 - If `self-diagnosis` command fails - exit code is greater than `0`
+- Minimal `php` version up to `v7.1.3`
+- Required package `illuminate/support` changed to `laravel/framework` *(this package uses ServiceProvider, ConsoleCommand classes from him)*
+
+### Fixed
+
+- Minimal `laravel/framework` package version is `5.6` ([v5.5](https://github.com/laravel/framework/blob/5.5/composer.json) requires `php >=7.0`, [v5.6](https://github.com/laravel/framework/blob/5.6/composer.json) requires `php >=^7.1.3`)
 
 [keepachangelog]:https://keepachangelog.com/en/1.0.0/
 [semver]:https://semver.org/spec/v2.0.0.html

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+        "php": "^7.1.3",
+        "laravel/framework": ">=5.6.0 <5.7.0",
         "vlucas/phpdotenv": "~2.5"
     },
     "require-dev": {
@@ -39,7 +39,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-
     },
     "config": {
         "sort-packages": true

--- a/src/Checks/ComposerWithDevDependenciesIsUpToDate.php
+++ b/src/Checks/ComposerWithDevDependenciesIsUpToDate.php
@@ -6,12 +6,21 @@ use BeyondCode\SelfDiagnosis\Composer;
 
 class ComposerWithDevDependenciesIsUpToDate implements Check
 {
-    /** @var Composer */
+    /**
+     * @var Composer
+     */
     private $composer;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $output;
 
+    /**
+     * ComposerWithDevDependenciesIsUpToDate constructor.
+     *
+     * @param Composer $composer
+     */
     public function __construct(Composer $composer)
     {
         $this->composer = $composer;

--- a/src/Checks/ComposerWithoutDevDependenciesIsUpToDate.php
+++ b/src/Checks/ComposerWithoutDevDependenciesIsUpToDate.php
@@ -6,12 +6,21 @@ use BeyondCode\SelfDiagnosis\Composer;
 
 class ComposerWithoutDevDependenciesIsUpToDate implements Check
 {
-    /** @var Composer */
+    /**
+     * @var Composer
+     */
     private $composer;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $output;
 
+    /**
+     * ComposerWithoutDevDependenciesIsUpToDate constructor.
+     *
+     * @param Composer $composer
+     */
     public function __construct(Composer $composer)
     {
         $this->composer = $composer;

--- a/src/Checks/ConfigurationIsCached.php
+++ b/src/Checks/ConfigurationIsCached.php
@@ -4,7 +4,6 @@ namespace BeyondCode\SelfDiagnosis\Checks;
 
 class ConfigurationIsCached implements Check
 {
-
     /**
      * The name of the check.
      *

--- a/src/Checks/ConfigurationIsNotCached.php
+++ b/src/Checks/ConfigurationIsNotCached.php
@@ -4,7 +4,6 @@ namespace BeyondCode\SelfDiagnosis\Checks;
 
 class ConfigurationIsNotCached implements Check
 {
-
     /**
      * The name of the check.
      *

--- a/src/Checks/CorrectPhpVersionIsInstalled.php
+++ b/src/Checks/CorrectPhpVersionIsInstalled.php
@@ -6,9 +6,16 @@ use Illuminate\Filesystem\Filesystem;
 
 class CorrectPhpVersionIsInstalled implements Check
 {
-    /** @var Filesystem */
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
 
+    /**
+     * CorrectPhpVersionIsInstalled constructor.
+     *
+     * @param Filesystem $filesystem
+     */
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;

--- a/src/Checks/DatabaseCanBeAccessed.php
+++ b/src/Checks/DatabaseCanBeAccessed.php
@@ -2,10 +2,13 @@
 
 namespace BeyondCode\SelfDiagnosis\Checks;
 
-use DB;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseCanBeAccessed implements Check
 {
+    /**
+     * @var string
+     */
     private $message;
 
     /**

--- a/src/Checks/DebugModeIsNotEnabled.php
+++ b/src/Checks/DebugModeIsNotEnabled.php
@@ -4,7 +4,6 @@ namespace BeyondCode\SelfDiagnosis\Checks;
 
 class DebugModeIsNotEnabled implements Check
 {
-
     /**
      * The name of the check.
      *

--- a/src/Checks/DirectoriesHaveCorrectPermissions.php
+++ b/src/Checks/DirectoriesHaveCorrectPermissions.php
@@ -7,14 +7,19 @@ use Illuminate\Filesystem\Filesystem;
 
 class DirectoriesHaveCorrectPermissions implements Check
 {
-    /** @var Filesystem */
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
 
-    /** @var Collection */
+    /**
+     * @var Collection
+     */
     private $paths;
 
     /**
      * DirectoriesHaveCorrectPermissions constructor.
+     *
      * @param Filesystem $filesystem
      */
     public function __construct(Filesystem $filesystem)

--- a/src/Checks/EnvFileExists.php
+++ b/src/Checks/EnvFileExists.php
@@ -6,10 +6,16 @@ use Illuminate\Filesystem\Filesystem;
 
 class EnvFileExists implements Check
 {
-
-    /** @var Filesystem */
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
 
+    /**
+     * EnvFileExists constructor.
+     *
+     * @param Filesystem $filesystem
+     */
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;

--- a/src/Checks/ExampleEnvironmentVariablesAreSet.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreSet.php
@@ -7,7 +7,9 @@ use Illuminate\Support\Collection;
 
 class ExampleEnvironmentVariablesAreSet implements Check
 {
-    /** @var Collection */
+    /**
+     * @var Collection
+     */
     private $envVariables;
 
     /**

--- a/src/Checks/MigrationsAreUpToDate.php
+++ b/src/Checks/MigrationsAreUpToDate.php
@@ -6,7 +6,10 @@ use Illuminate\Support\Facades\Artisan;
 
 class MigrationsAreUpToDate implements Check
 {
-    private $databaseError = null;
+    /**
+     * @var string|null
+     */
+    private $databaseError;
 
     /**
      * The name of the check.

--- a/src/Checks/PhpExtensionsAreDisabled.php
+++ b/src/Checks/PhpExtensionsAreDisabled.php
@@ -6,8 +6,9 @@ use Illuminate\Support\Collection;
 
 class PhpExtensionsAreDisabled implements Check
 {
-
-    /** @var Collection */
+    /**
+     * @var Collection
+     */
     private $extensions;
 
     /**

--- a/src/Checks/PhpExtensionsAreInstalled.php
+++ b/src/Checks/PhpExtensionsAreInstalled.php
@@ -7,12 +7,18 @@ use Illuminate\Support\Collection;
 
 class PhpExtensionsAreInstalled implements Check
 {
-
     const EXT = 'ext-';
 
-    /** @var Filesystem */
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
 
+    /**
+     * PhpExtensionsAreInstalled constructor.
+     *
+     * @param Filesystem $filesystem
+     */
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
@@ -84,5 +90,4 @@ class PhpExtensionsAreInstalled implements Check
         }
         return array_unique($extensions);
     }
-
 }

--- a/src/Checks/RoutesAreCached.php
+++ b/src/Checks/RoutesAreCached.php
@@ -4,7 +4,6 @@ namespace BeyondCode\SelfDiagnosis\Checks;
 
 class RoutesAreCached implements Check
 {
-
     /**
      * The name of the check.
      *

--- a/src/Checks/RoutesAreNotCached.php
+++ b/src/Checks/RoutesAreNotCached.php
@@ -4,7 +4,6 @@ namespace BeyondCode\SelfDiagnosis\Checks;
 
 class RoutesAreNotCached implements Check
 {
-
     /**
      * The name of the check.
      *

--- a/src/Checks/StorageDirectoryIsLinked.php
+++ b/src/Checks/StorageDirectoryIsLinked.php
@@ -6,9 +6,16 @@ use Illuminate\Filesystem\Filesystem;
 
 class StorageDirectoryIsLinked implements Check
 {
-    /** @var Filesystem */
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
 
+    /**
+     * StorageDirectoryIsLinked constructor.
+     *
+     * @param Filesystem $filesystem
+     */
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -4,6 +4,11 @@ namespace BeyondCode\SelfDiagnosis;
 
 class Composer extends \Illuminate\Support\Composer
 {
+    /**
+     * @param string|null $options
+     *
+     * @return string
+     */
     public function installDryRun(string $options = null)
     {
         $process = $this->getProcess();

--- a/src/SelfDiagnosisCommand.php
+++ b/src/SelfDiagnosisCommand.php
@@ -21,8 +21,16 @@ class SelfDiagnosisCommand extends Command
      */
     protected $description = 'Perform application self diagnosis.';
 
+    /**
+     * Messages stack.
+     *
+     * @var string[]
+     */
     private $messages = [];
 
+    /**
+     * Execute the console command.
+     */
     public function handle()
     {
         $this->runChecks(config('self-diagnosis.checks', []), trans('self-diagnosis::commands.self_diagnosis.common_checks'));
@@ -78,6 +86,12 @@ class SelfDiagnosisCommand extends Command
         $this->output->writeln('');
     }
 
+    /**
+     * Make check run.
+     *
+     * @param Check $check
+     * @param array $config
+     */
     protected function runCheck(Check $check, array $config)
     {
         if ($check->check($config)) {

--- a/src/SelfDiagnosisCommand.php
+++ b/src/SelfDiagnosisCommand.php
@@ -2,8 +2,10 @@
 
 namespace BeyondCode\SelfDiagnosis;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use BeyondCode\SelfDiagnosis\Checks\Check;
+use Illuminate\Contracts\Foundation\Application;
 
 class SelfDiagnosisCommand extends Command
 {
@@ -30,39 +32,53 @@ class SelfDiagnosisCommand extends Command
 
     /**
      * Execute the console command.
+     *
+     * @param Application $app
+     *
+     * @return int
      */
-    public function handle()
+    public function handle(Application $app)
     {
-        $this->runChecks(config('self-diagnosis.checks', []), trans('self-diagnosis::commands.self_diagnosis.common_checks'));
+        $this->runChecks(
+            config('self-diagnosis.checks', []),
+            trans('self-diagnosis::commands.self_diagnosis.common_checks')
+        );
 
-        $environmentChecks = config('self-diagnosis.environment_checks.' . app()->environment(), []);
-        if (empty($environmentChecks) && array_key_exists(app()->environment(), config('self-diagnosis.environment_aliases'))) {
-            $environment = config('self-diagnosis.environment_aliases.' . app()->environment());
+        $environmentChecks = config('self-diagnosis.environment_checks.' . $app->environment(), []);
+        if (empty($environmentChecks) && array_key_exists($app->environment(), config('self-diagnosis.environment_aliases'))) {
+            $environment = config('self-diagnosis.environment_aliases.' . $app->environment());
             $environmentChecks = config('self-diagnosis.environment_checks.' . $environment, []);
         }
 
-        $this->runChecks($environmentChecks, trans('self-diagnosis::commands.self_diagnosis.environment_specific_checks', ['environment' => app()->environment()]));
+        $this->runChecks($environmentChecks, trans('self-diagnosis::commands.self_diagnosis.environment_specific_checks', ['environment' => $app->environment()]));
 
-        if (count($this->messages)) {
+        if (\count($this->messages)) {
             $this->error(trans('self-diagnosis::commands.self_diagnosis.failed_checks'));
 
             foreach ($this->messages as $message) {
-                $this->output->writeln('<fg=red>'.$message.'</fg=red>');
-                $this->output->writeln('');
+                $this->output->writeln('<fg=red>'.$message.'</fg=red>' . PHP_EOL);
             }
-        } else {
-            $this->info(trans('self-diagnosis::commands.self_diagnosis.success'));
+
+            return 1; // Exit WITH error (EXIT_CODE != 0)
         }
+
+        $this->info(trans('self-diagnosis::commands.self_diagnosis.success'));
+
+        return 0; // Exit without error (EXIT_CODE = 0)
     }
 
+    /**
+     * Run checks.
+     *
+     * @param array  $checks
+     * @param string $title
+     */
     protected function runChecks(array $checks, string $title)
     {
-        $max = count($checks);
+        $max = \count($checks);
         $current = 1;
 
-        $this->output->writeln('|-------------------------------------');
-        $this->output->writeln('| '.$title);
-        $this->output->writeln('|-------------------------------------');
+        $this->drawBox($title);
 
         foreach ($checks as $check => $config) {
             if (is_numeric($check)) {
@@ -84,6 +100,22 @@ class SelfDiagnosisCommand extends Command
         }
 
         $this->output->writeln('');
+    }
+
+    /**
+     * Draw message in a box.
+     *
+     * @param string $title
+     */
+    protected function drawBox(string $title)
+    {
+        $length = Str::length(strip_tags($title)) + 8;
+
+        $this->output->writeln('|' . str_repeat('-', $length) . '|');
+        $this->output->writeln('|    ' . $title . '    |');
+        $this->output->writeln('|' . str_repeat('-', $length) . '|');
+
+        $this->output->newLine();
     }
 
     /**

--- a/src/SelfDiagnosisServiceProvider.php
+++ b/src/SelfDiagnosisServiceProvider.php
@@ -7,7 +7,7 @@ use Illuminate\Support\ServiceProvider;
 class SelfDiagnosisServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap the application services.
+     * Bootstrap package services.
      */
     public function boot()
     {


### PR DESCRIPTION
## 1.5.0 - 2018-XX-XX

### Changed

- DocBlocks updated
- If `self-diagnosis` command fails - exit code is greater than `0`
- Minimal `php` version up to `v7.1.3`
- Required package `illuminate/support` changed to `laravel/framework` *(this package uses ServiceProvider, ConsoleCommand classes from him)*

### Fixed

- Minimal `laravel/framework` package version is `5.6` ([v5.5](https://github.com/laravel/framework/blob/5.5/composer.json) requires `php >=7.0`, [v5.6](https://github.com/laravel/framework/blob/5.6/composer.json) requires `php >=^7.1.3`)