### PR TITLE
Adds a new SupervisorProgramsAreRunning check

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ return [
                 ],
             ],
             \BeyondCode\SelfDiagnosis\Checks\RoutesAreCached::class,
+            \BeyondCode\SelfDiagnosis\Checks\SupervisorProgramsAreRunning::class => [
+                'programs' => [
+                    'horizon',
+                ],
+                'restarted_within' => 300, // max seconds since last restart, 0 to disable check
+            ],
         ],
     ],
 
@@ -159,6 +165,9 @@ The following options are available for the individual checks:
 - [`BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreInstalled`](src/Checks/PhpExtensionsAreInstalled.php)
   - **extensions** *(array, list of extension names like `['openssl', 'PDO']`, default: `[]`)*: extensions to check
   - **include_composer_extensions** *(boolean, default: `false`)*: if required extensions defined in `composer.json` should be checked
+- [`BeyondCode\SelfDiagnosis\Checks\SupervisorProgramsAreRunning`](src/Checks/SupervisorProgramsAreRunning.php)
+  - **programs** *(array, list of programs like `['horizon', 'another-program']`, default: `[]`)*: programs that are required to be running
+  - **restarted_within** *(integer, max allowed seconds since last restart of programs (`0` = disabled), default: `0`)*: verifies that programs have been restarted recently to grab code updates
 
 ### Custom Checks
 

--- a/config/config.php
+++ b/config/config.php
@@ -70,12 +70,12 @@ return [
                 ],
             ],
             \BeyondCode\SelfDiagnosis\Checks\RoutesAreCached::class,
-            \BeyondCode\SelfDiagnosis\Checks\SupervisorProgramsAreRunning::class => [
-                'programs' => [
-                    'horizon',
-                ],
-                'restarted_within' => 300, // max seconds since last restart, 0 to disable check
-            ],
+            //\BeyondCode\SelfDiagnosis\Checks\SupervisorProgramsAreRunning::class => [
+            //    'programs' => [
+            //        'horizon',
+            //    ],
+            //    'restarted_within' => 300,
+            //],
         ],
     ],
 

--- a/config/config.php
+++ b/config/config.php
@@ -70,6 +70,12 @@ return [
                 ],
             ],
             \BeyondCode\SelfDiagnosis\Checks\RoutesAreCached::class,
+            \BeyondCode\SelfDiagnosis\Checks\SupervisorProgramsAreRunning::class => [
+                'programs' => [
+                    'horizon',
+                ],
+                'restarted_within' => 300, // max seconds since last restart, 0 to disable check
+            ],
         ],
     ],
 

--- a/src/Checks/SupervisorProgramsAreRunning.php
+++ b/src/Checks/SupervisorProgramsAreRunning.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Checks;
+
+use BeyondCode\SelfDiagnosis\SystemFunctions;
+use Illuminate\Support\Collection;
+
+class SupervisorProgramsAreRunning implements Check
+{
+    /** @var Collection */
+    protected $notRunningPrograms;
+
+    /** @var string|null */
+    protected $message;
+
+    /** @var SystemFunctions */
+    protected $systemFunctions;
+
+    /** @var string */
+    protected const REGEX_SUPERVISORCTL_STATUS = '/^(\S+)\s+RUNNING\s+pid\s+(\d+),\s+uptime\s+(\d+):(\d+):(\d+)$/';
+
+    /**
+     * SupervisorProgramsAreRunning constructor.
+     *
+     * @param SystemFunctions $systemFunctions
+     */
+    public function __construct(SystemFunctions $systemFunctions)
+    {
+        $this->systemFunctions = $systemFunctions;
+    }
+
+    /**
+     * The name of the check.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function name(array $config): string
+    {
+        return trans('self-diagnosis::checks.supervisor_programs_are_running.name');
+    }
+
+    /**
+     * Perform the actual verification of this check.
+     *
+     * @param array $config
+     * @return bool
+     */
+    public function check(array $config): bool
+    {
+        $this->notRunningPrograms = new Collection(array_get($config, 'programs', []));
+        if ($this->notRunningPrograms->isEmpty()) {
+            return true;
+        }
+
+        if (!$this->systemFunctions->isFunctionAvailable('shell_exec')) {
+            $this->message = trans('self-diagnosis::checks.supervisor_programs_are_running.message.shell_exec_not_available');
+            return false;
+        }
+
+        if ($this->systemFunctions->isWindowsOperatingSystem()) {
+            $this->message = trans('self-diagnosis::checks.supervisor_programs_are_running.message.cannot_run_on_windows');
+            return false;
+        }
+
+        $programs = $this->systemFunctions->callShellExec('supervisorctl status');
+        if ($programs === null || $programs === '') {
+            $this->message = trans('self-diagnosis::checks.supervisor_programs_are_running.message.supervisor_command_not_available');
+            return false;
+        }
+
+        $restartedWithin = array_get($config, 'restarted_within', 0);
+        $programs = explode("\n" , $programs);
+        foreach ($programs as $program) {
+            /*
+             * Capture groups of regex:
+             * (program name) (process id) (uptime hours) (minutes) (seconds)
+             */
+            $isMatch = preg_match(self::REGEX_SUPERVISORCTL_STATUS, trim($program), $matches);
+            if ($isMatch) {
+                if ($restartedWithin > 0) {
+                    $totalSeconds = $matches[3] * 3600 + $matches[4] * 60 + $matches[5];
+                    if ($totalSeconds > $restartedWithin) {
+                        continue;
+                    }
+                }
+
+                $this->notRunningPrograms = $this->notRunningPrograms->reject(function ($item) use ($matches) {
+                    return $item === $matches[1];
+                });
+            }
+        }
+
+        return $this->notRunningPrograms->isEmpty();
+    }
+
+    /**
+     * The error message to display in case the check does not pass.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function message(array $config): string
+    {
+        if ($this->message) {
+            return $this->message;
+        }
+
+        return trans('self-diagnosis::checks.supervisor_programs_are_running.message.not_running_programs', [
+            'programs' => $this->notRunningPrograms->implode(PHP_EOL),
+        ]);
+    }
+}

--- a/tests/SupervisorProgramsAreRunningTest.php
+++ b/tests/SupervisorProgramsAreRunningTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Tests;
+
+use BeyondCode\SelfDiagnosis\SelfDiagnosisServiceProvider;
+use BeyondCode\SelfDiagnosis\SystemFunctions;
+use Orchestra\Testbench\TestCase;
+use BeyondCode\SelfDiagnosis\Checks\SupervisorProgramsAreRunning;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SupervisorProgramsAreRunningTest extends TestCase
+{
+    public function getPackageProviders($app)
+    {
+        return [
+            SelfDiagnosisServiceProvider::class,
+        ];
+    }
+
+    /** @test */
+    public function it_succeeds_when_no_programs_need_to_run()
+    {
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+
+        $check = new SupervisorProgramsAreRunning($systemFunctionsMock);
+        $result = $check->check([]);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_succeeds_when_all_programs_are_running()
+    {
+        $config = ['programs' => ['process-1', 'process-2']];
+        $supervisorStatus = "process-1                          RUNNING   pid 3004, uptime 0:01:23\nprocess-2                          RUNNING   pid 3005, uptime 0:01:23";
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(false);
+        $systemFunctionsMock->expects($this->once())
+            ->method('callShellExec')
+            ->with('supervisorctl status')
+            ->willReturn($supervisorStatus);
+
+        $check = new SupervisorProgramsAreRunning($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_succeeds_when_all_programs_are_running_and_were_recently_restarted()
+    {
+        $config = [
+            'programs' => ['process-1', 'process-2'],
+            'restarted_within' => 300,
+        ];
+        $supervisorStatus = "process-1                          RUNNING   pid 3004, uptime 0:01:23\nprocess-2                          RUNNING   pid 3005, uptime 0:05:00";
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(false);
+        $systemFunctionsMock->expects($this->once())
+            ->method('callShellExec')
+            ->with('supervisorctl status')
+            ->willReturn($supervisorStatus);
+
+        $check = new SupervisorProgramsAreRunning($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function it_fails_when_shell_exec_is_not_available()
+    {
+        $config = ['programs' => ['process-1', 'process-2']];
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(false);
+
+        $check = new SupervisorProgramsAreRunning($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame('The function "shell_exec" is not defined or disabled, so we cannot check the running programs.', $check->message($config));
+    }
+
+    /** @test */
+    public function it_fails_when_run_on_windows()
+    {
+        $config = ['programs' => ['process-1', 'process-2']];
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(true);
+
+        $check = new SupervisorProgramsAreRunning($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame('This check cannot be run on Windows.', $check->message($config));
+    }
+
+    /** @test */
+    public function it_fails_when_supervisorctl_command_is_not_available()
+    {
+        $config = ['programs' => ['process-1', 'process-2']];
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(false);
+        $systemFunctionsMock->expects($this->once())
+            ->method('callShellExec')
+            ->with('supervisorctl status')
+            ->willReturn('');
+
+        $check = new SupervisorProgramsAreRunning($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame('The "supervisorctl" command is not available on the current OS.', $check->message($config));
+    }
+
+    /** @test */
+    public function it_fails_when_not_all_programs_are_running()
+    {
+        $config = ['programs' => ['process-1', 'process-2', 'process-3']];
+        $supervisorStatus = "process-1                          RUNNING   pid 3004, uptime 0:01:23\nprocess-2                      STOPPED   Jul 12 03:37 PM";
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(false);
+        $systemFunctionsMock->expects($this->once())
+            ->method('callShellExec')
+            ->with('supervisorctl status')
+            ->willReturn($supervisorStatus);
+
+        $check = new SupervisorProgramsAreRunning($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame("The following programs are not running or require a restart:\nprocess-2\nprocess-3", $check->message($config));
+    }
+
+    /** @test */
+    public function it_fails_when_some_program_was_not_restarted_recently()
+    {
+        $config = [
+            'programs' => ['process-1'],
+            'restarted_within' => 300,
+        ];
+        $supervisorStatus = "process-1                          RUNNING   pid 3004, uptime 0:05:01";
+
+        /** @var MockObject|SystemFunctions $systemFunctionsMock */
+        $systemFunctionsMock = $this->createMock(SystemFunctions::class);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isFunctionAvailable')
+            ->with('shell_exec')
+            ->willReturn(true);
+        $systemFunctionsMock->expects($this->once())
+            ->method('isWindowsOperatingSystem')
+            ->willReturn(false);
+        $systemFunctionsMock->expects($this->once())
+            ->method('callShellExec')
+            ->with('supervisorctl status')
+            ->willReturn($supervisorStatus);
+
+        $check = new SupervisorProgramsAreRunning($systemFunctionsMock);
+        $result = $check->check($config);
+
+        $this->assertFalse($result);
+        $this->assertSame("The following programs are not running or require a restart:\nprocess-1", $check->message($config));
+    }
+}

--- a/translations/de/checks.php
+++ b/translations/de/checks.php
@@ -81,4 +81,13 @@ return [
         'message' => 'Das Speicherverzeichnis ist nicht verlinkt. Nutze "php artisan storage:link", um eine symbolische Verknüpfung zu erstellen.',
         'name' => 'Das Speicherverzeichnis ist verlinkt',
     ],
+    'supervisor_programs_are_running' => [
+        'message' => [
+            'cannot_run_on_windows' => 'Dieser Check kann unter Windows nicht ausgeführt werden..',
+            'not_running_programs' => 'Die folgenden Programme laufen nicht oder benötigen einen Neustart:' . PHP_EOL . ':programs',
+            'shell_exec_not_available' => 'Die Funktion "shell_exec" ist entweder nicht definiert oder deaktiviert, daher können die laufenden Programme nicht abgefragt werden.',
+            'supervisor_command_not_available' => 'Der Befehl "supervisorctl" ist auf dem aktuellen System nicht verfügbar.',
+        ],
+        'name' => 'Alle supervisor Programme sind in Betrieb',
+    ],
 ];

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -81,4 +81,13 @@ return [
         'message' => 'The storage directory is not linked. Use "php artisan storage:link" to create a symbolic link.',
         'name' => 'The storage directory is linked',
     ],
+    'supervisor_programs_are_running' => [
+        'message' => [
+            'cannot_run_on_windows' => 'This check cannot be run on Windows.',
+            'not_running_programs' => 'The following programs are not running or require a restart:' . PHP_EOL . ':programs',
+            'shell_exec_not_available' => 'The function "shell_exec" is not defined or disabled, so we cannot check the running programs.',
+            'supervisor_command_not_available' => 'The "supervisorctl" command is not available on the current OS.',
+        ],
+        'name' => 'All supervisor programs are running',
+    ],
 ];


### PR DESCRIPTION
This check ensures that some supervisord programs are running, e.g. horizon. It can also ensure these programs have been restarted recently, i.e. to grab code updates.

It will use `shell_exec` to call `supervisorctl status`:
```
vagrant@dev:~/eval1$ supervisorctl status
horizon                          RUNNING   pid 3004, uptime 0:06:15
horizon2                         STOPPED   Jul 12 07:37 PM
```
This output will be parsed line by line with the help of a regex to identify the individual programs. Also the uptime is parsed to perform an additional check that ensures it is below a certain threshold (or in other words, ensures that the program was recently restarted).

There should be unit tests included for almost every code path.