### PR TITLE
Adds a new MaintenanceModeNotEnabled check

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ return [
                 'en_US.utf8',
             ],
         ],
+        \BeyondCode\SelfDiagnosis\Checks\MaintenanceModeNotEnabled::class,
         \BeyondCode\SelfDiagnosis\Checks\MigrationsAreUpToDate::class,
         \BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreInstalled::class => [
             'extensions' => [

--- a/config/config.php
+++ b/config/config.php
@@ -35,6 +35,7 @@ return [
                 'en_US.utf8',
             ],
         ],
+        \BeyondCode\SelfDiagnosis\Checks\MaintenanceModeNotEnabled::class,
         \BeyondCode\SelfDiagnosis\Checks\MigrationsAreUpToDate::class,
         \BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreInstalled::class => [
             'extensions' => [

--- a/src/Checks/MaintenanceModeNotEnabled.php
+++ b/src/Checks/MaintenanceModeNotEnabled.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Checks;
+
+class MaintenanceModeNotEnabled implements Check
+{
+    /**
+     * The name of the check.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function name(array $config): string
+    {
+        return trans('self-diagnosis::checks.maintenance_mode_not_enabled.name');
+    }
+
+    /**
+     * Perform the actual verification of this check.
+     *
+     * @param array $config
+     * @return bool
+     */
+    public function check(array $config): bool
+    {
+        return app()->isDownForMaintenance() === false;
+    }
+
+    /**
+     * The error message to display in case the check does not pass.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function message(array $config): string
+    {
+        return trans('self-diagnosis::checks.maintenance_mode_not_enabled.message');
+    }
+}

--- a/translations/de/checks.php
+++ b/translations/de/checks.php
@@ -54,6 +54,10 @@ return [
         ],
         'name' => 'Benötigte Sprachumgebungen sind installiert',
     ],
+    'maintenance_mode_not_enabled' => [
+        'message' => 'Der Wartungsmodus ist noch aktiv. Deaktiviere ihn mit "php artisan up".',
+        'name' => 'Wartungsmodus ist nicht aktiv',
+    ],
     'migrations_are_up_to_date' => [
         'message' => [
             'need_to_migrate' => 'Die Datenbank muss aktualisiert werden. Nutze "php artisan migrate", um die Migrationen einzuspielen.',

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -54,6 +54,10 @@ return [
         ],
         'name' => 'Required locales are installed',
     ],
+    'maintenance_mode_not_enabled' => [
+        'message' => 'Maintenance mode is still enabled. Disable it with "php artisan up".',
+        'name' => 'Maintenance mode is not enabled',
+    ],
     'migrations_are_up_to_date' => [
         'message' => [
             'need_to_migrate' => 'You need to update your database. Call "php artisan migrate" to run migrations.',


### PR DESCRIPTION
This check ensures the application is not in maintenance mode and reachable for users. The PR does not include any tests because mocking the application is quite hard when you have to override the `app()` helper. But the complexity of the check is rather low anyway.

To be fair, I'm not sure if this check is something you desire. Unlocking the application may actually be something you expect to happen after the self-diagnosis was run successfully. But even if it is something that will always fail during the first run of the self-diagnosis, I kind of like it as it reminds me of something important.