### PR TITLE
Adds a new ServersArePingable check

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ return [
                 ],
             ],
             \BeyondCode\SelfDiagnosis\Checks\RoutesAreCached::class,
+            \BeyondCode\SelfDiagnosis\Checks\ServersArePingable::class => [
+                'servers' => [
+                    'www.google.com',
+                    ['host' => 'www.google.com', 'port' => 8080],
+                    '8.8.8.8',
+                    ['host' => '8.8.8.8', 'port' => 8080, 'timeout' => 5],
+                ],
+            ],
         ],
     ],
 
@@ -159,6 +167,8 @@ The following options are available for the individual checks:
 - [`BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreInstalled`](src/Checks/PhpExtensionsAreInstalled.php)
   - **extensions** *(array, list of extension names like `['openssl', 'PDO']`, default: `[]`)*: extensions to check
   - **include_composer_extensions** *(boolean, default: `false`)*: if required extensions defined in `composer.json` should be checked
+- [`BeyondCode\SelfDiagnosis\Checks\ServersArePingable`](src/Checks/ServersArePingable.php)
+  - **servers** *(array, list of servers and parameters like `['google.com', ['host' => 'google.com', 'port' => 8080]]`)*: servers to ping
 
 ### Custom Checks
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "geerlingguy/ping": "^1.1",
         "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
         "vlucas/phpdotenv": "~2.5"
     },

--- a/config/config.php
+++ b/config/config.php
@@ -70,6 +70,14 @@ return [
                 ],
             ],
             \BeyondCode\SelfDiagnosis\Checks\RoutesAreCached::class,
+            //\BeyondCode\SelfDiagnosis\Checks\ServersArePingable::class => [
+            //    'servers' => [
+            //        'www.google.com',
+            //        ['host' => 'www.google.com', 'port' => 8080],
+            //        '8.8.8.8',
+            //        ['host' => '8.8.8.8', 'port' => 8080, 'timeout' => 5],
+            //    ],
+            //],
         ],
     ],
 

--- a/src/Checks/ServersArePingable.php
+++ b/src/Checks/ServersArePingable.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Checks;
+
+use BeyondCode\SelfDiagnosis\Exceptions\InvalidConfigurationException;
+use BeyondCode\SelfDiagnosis\Server;
+use Illuminate\Support\Collection;
+use JJG\Ping;
+
+class ServersArePingable implements Check
+{
+    protected const DEFAULT_TIMEOUT = 5;
+
+    /** @var Collection */
+    protected $notReachableServers;
+
+    /**
+     * The name of the check.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function name(array $config): string
+    {
+        return trans('self-diagnosis::checks.servers_are_pingable.name');
+    }
+
+    /**
+     * Perform the actual verification of this check.
+     *
+     * @param array $config
+     * @return bool
+     * @throws InvalidConfigurationException
+     */
+    public function check(array $config): bool
+    {
+        $this->notReachableServers = $this->parseConfiguredServers(array_get($config, 'servers', []));
+        if ($this->notReachableServers->isEmpty()) {
+            return true;
+        }
+
+        $this->notReachableServers = $this->notReachableServers->reject(function (Server $server) {
+            $ping = new Ping($server->getHost());
+            $ping->setPort($server->getPort());
+            $ping->setTimeout($server->getTimeout());
+
+            if ($ping->getPort() === null) {
+                $latency = $ping->ping('exec');
+            } else {
+                $latency = $ping->ping('fsockopen');
+            }
+
+            return $latency !== false;
+        });
+
+        return $this->notReachableServers->isEmpty();
+    }
+
+    /**
+     * The error message to display in case the check does not pass.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function message(array $config): string
+    {
+        return $this->notReachableServers->map(function (Server $server) {
+            return trans('self-diagnosis::checks.servers_are_pingable.message', [
+                'host' => $server->getHost(),
+                'port' => $server->getPort() ?? 'n/a',
+                'timeout' => $server->getTimeout(),
+            ]);
+        })->implode(PHP_EOL);
+    }
+
+    /**
+     * Parses an array of servers which can be given in different formats.
+     * Unifies the format for the resulting collection.
+     *
+     * @param array $servers
+     * @return Collection
+     * @throws InvalidConfigurationException
+     */
+    private function parseConfiguredServers(array $servers): Collection
+    {
+        $result = new Collection();
+
+        foreach ($servers as $server) {
+            if (is_array($server)) {
+                if (!empty(array_except($server, ['host', 'port', 'timeout']))) {
+                    throw new InvalidConfigurationException('Servers in array notation may only contain a host, port and timeout parameter.');
+                }
+                if (!array_has($server, 'host')) {
+                    throw new InvalidConfigurationException('For servers in array notation, the host parameter is required.');
+                }
+
+                $host = array_get($server, 'host');
+                $port = array_get($server, 'port');
+                $timeout = array_get($server, 'timeout', self::DEFAULT_TIMEOUT);
+
+                $result->push(new Server($host, $port, $timeout));
+            } else if (is_string($server)) {
+                $result->push(new Server($server, null, self::DEFAULT_TIMEOUT));
+            } else {
+                throw new InvalidConfigurationException('The server configuration may only contain arrays or strings.');
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Exceptions/InvalidConfigurationException.php
+++ b/src/Exceptions/InvalidConfigurationException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Exceptions;
+
+/**
+ * Exception to be used when an invalid check configuration is encountered.
+ *
+ * @package BeyondCode\SelfDiagnosis\Exceptions
+ */
+class InvalidConfigurationException extends \Exception
+{
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis;
+
+/**
+ * DTO class for a server used by the ping check.
+ *
+ * @package BeyondCode\SelfDiagnosis
+ */
+class Server
+{
+    /** @var string */
+    protected $host;
+
+    /** @var int|null */
+    protected $port;
+
+    /** @var int */
+    protected $timeout;
+
+    public function __construct(string $host, ?int $port, int $timeout)
+    {
+        $this->host = $host;
+        $this->port = $port;
+        $this->timeout = $timeout;
+    }
+
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    public function getPort(): ?int
+    {
+        return $this->port;
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+}

--- a/tests/ServersArePingableTest.php
+++ b/tests/ServersArePingableTest.php
@@ -24,20 +24,6 @@ class ServersArePingableTest extends TestCase
     }
 
     /** @test */
-    public function it_succeeds_when_all_all_servers_are_pingable()
-    {
-        $config = ['servers' => [
-            '127.0.0.1',
-            'localhost',
-            ['host' => '127.0.0.1'],
-            ['host' => 'localhost']
-        ]];
-
-        $check = new ServersArePingable();
-        $this->assertTrue($check->check($config));
-    }
-
-    /** @test */
     public function it_fails_when_numeric_server_host_is_given()
     {
         $config = ['servers' => [1234567890]];

--- a/tests/ServersArePingableTest.php
+++ b/tests/ServersArePingableTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Tests;
+
+use BeyondCode\SelfDiagnosis\Checks\ServersArePingable;
+use BeyondCode\SelfDiagnosis\Exceptions\InvalidConfigurationException;
+use BeyondCode\SelfDiagnosis\SelfDiagnosisServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class ServersArePingableTest extends TestCase
+{
+    public function getPackageProviders($app)
+    {
+        return [
+            SelfDiagnosisServiceProvider::class,
+        ];
+    }
+
+    /** @test */
+    public function it_succeeds_when_no_servers_are_given()
+    {
+        $check = new ServersArePingable();
+        $this->assertTrue($check->check([]));
+    }
+
+    /** @test */
+    public function it_succeeds_when_all_all_servers_are_pingable()
+    {
+        $config = ['servers' => [
+            '127.0.0.1',
+            'localhost',
+            ['host' => '127.0.0.1'],
+            ['host' => 'localhost']
+        ]];
+
+        $check = new ServersArePingable();
+        $this->assertTrue($check->check($config));
+    }
+
+    /** @test */
+    public function it_fails_when_numeric_server_host_is_given()
+    {
+        $config = ['servers' => [1234567890]];
+
+        $check = new ServersArePingable();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $check->check($config);
+    }
+
+    /** @test */
+    public function it_fails_when_no_host_key_is_given_for_server_in_array_form()
+    {
+        $config = ['servers' => [['port' => 80]]];
+
+        $check = new ServersArePingable();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $check->check($config);
+    }
+
+    /** @test */
+    public function it_fails_when_not_supported_keys_are_given_for_server_in_array_form()
+    {
+        $config = ['servers' => [['host' => 'localhost', 'unsupported_param' => true]]];
+
+        $check = new ServersArePingable();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $check->check($config);
+    }
+
+    /** @test */
+    public function it_fails_when_the_server_ip_cannot_be_resolved()
+    {
+        $config = ['servers' => [['host' => 'somethingthatdoesnotexist.local', 'timeout' => 1]]];
+
+        $check = new ServersArePingable();
+        $this->assertFalse($check->check($config));
+        $this->assertSame("The server 'somethingthatdoesnotexist.local' (port: n/a) is not reachable (timeout after 1 seconds).", $check->message($config));
+    }
+}

--- a/translations/de/checks.php
+++ b/translations/de/checks.php
@@ -77,6 +77,10 @@ return [
         'message' => 'Die Routen sollten während der Entwicklung nicht gecached sein. Nutze "php artisan route:clear", um den Routen-Cache zu leeren.',
         'name' => 'Routen sind nicht gecached',
     ],
+    'servers_are_pingable' => [
+        'message' => "Der Server ':host' (Port: :port) ist nicht erreichbar (Timeout nach :timeout Sekunden).",
+        'name' => 'Benötigte Server sind pingbar',
+    ],
     'storage_directory_is_linked' => [
         'message' => 'Das Speicherverzeichnis ist nicht verlinkt. Nutze "php artisan storage:link", um eine symbolische Verknüpfung zu erstellen.',
         'name' => 'Das Speicherverzeichnis ist verlinkt',

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -77,6 +77,10 @@ return [
         'message' => 'Your routes should not be cached during development. Call "php artisan route:clear" to clear the route cache.',
         'name' => 'Routes are not cached',
     ],
+    'servers_are_pingable' => [
+        'message' => "The server ':host' (port: :port) is not reachable (timeout after :timeout seconds).",
+        'name' => 'Required servers are pingable',
+    ],
     'storage_directory_is_linked' => [
         'message' => 'The storage directory is not linked. Use "php artisan storage:link" to create a symbolic link.',
         'name' => 'The storage directory is linked',


### PR DESCRIPTION
This check can be used to check firewall rules for example. One usecase would be to ping API servers an application depends on, to make sure they are reachable. The check does not make sure an API itself is online though (i.e. returns valid results).