### PR TITLE
Fix logic error in SystemFunctions helper class

### DIFF
--- a/src/SystemFunctions.php
+++ b/src/SystemFunctions.php
@@ -29,7 +29,7 @@ class SystemFunctions
      */
     public function isFunctionAvailable(string $function): bool
     {
-        return is_callable($function) && true === stripos(ini_get('disable_functions'), $function);
+        return is_callable($function) && false === stripos(ini_get('disable_functions'), $function);
     }
 
     /**


### PR DESCRIPTION
I just noticed that there is a logic error in the `SystemFunctions` class which will cause `isFunctionAvailable($func)` to always return false. This PR should fix the issue.