### PR TITLE
Fixes RedisCanBeAccessed inconsistent check results

### DIFF
--- a/tests/RedisCanBeAccessedTest.php
+++ b/tests/RedisCanBeAccessedTest.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\SelfDiagnosis\Tests;
 
+use BeyondCode\SelfDiagnosis\SelfDiagnosisServiceProvider;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Facades\Redis;
 use Orchestra\Testbench\TestCase;
@@ -10,28 +11,37 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class RedisCanBeAccessedTest extends TestCase
 {
+    public function getPackageProviders($app)
+    {
+        return [
+            SelfDiagnosisServiceProvider::class,
+        ];
+    }
+
     /** @test */
-    public function it_checks_default_cache_access()
+    public function it_succeeds_when_default_connection_works()
     {
         $check = app(RedisCanBeAccessed::class);
         $this->assertFalse($check->check([]));
 
         /** @var MockObject|Connection $connectionMock */
         $connectionMock = $this->getMockBuilder(Connection::class)
-            ->setMethods(['isConnected', 'createSubscription']) // we have to declare the abstract method createSubscription
+            ->setMethods(['connect', 'isConnected', 'createSubscription']) // we have to declare the abstract method createSubscription
             ->getMock();
+        $connectionMock->expects($this->once())
+            ->method('connect');
         $connectionMock->expects($this->once())
             ->method('isConnected')
             ->willReturn(true);
 
         Redis::shouldReceive('connection')
-            ->withNoArgs()
+            ->with(null)
             ->andReturn($connectionMock);
         $this->assertTrue($check->check([]));
     }
 
     /** @test */
-    public function it_checks_named_cache_access()
+    public function it_succeeds_when_named_connections_work()
     {
         $config = [
             'default_connection' => false,
@@ -45,8 +55,10 @@ class RedisCanBeAccessedTest extends TestCase
 
         /** @var MockObject|Connection $connectionMock */
         $connectionMock = $this->getMockBuilder(Connection::class)
-            ->setMethods(['isConnected', 'createSubscription']) // we have to declare the abstract method createSubscription
+            ->setMethods(['connect', 'isConnected', 'createSubscription']) // we have to declare the abstract method createSubscription
             ->getMock();
+        $connectionMock->expects($this->once())
+            ->method('connect');
         $connectionMock->expects($this->once())
             ->method('isConnected')
             ->willReturn(true);
@@ -55,5 +67,58 @@ class RedisCanBeAccessedTest extends TestCase
             ->with('some_connection')
             ->andReturn($connectionMock);
         $this->assertTrue($check->check($config));
+    }
+
+    /** @test */
+    public function it_fails_when_default_connection_does_not_work()
+    {
+        $check = app(RedisCanBeAccessed::class);
+        $this->assertFalse($check->check([]));
+
+        /** @var MockObject|Connection $connectionMock */
+        $connectionMock = $this->getMockBuilder(Connection::class)
+            ->setMethods(['connect', 'isConnected', 'createSubscription']) // we have to declare the abstract method createSubscription
+            ->getMock();
+        $connectionMock->expects($this->once())
+            ->method('connect');
+        $connectionMock->expects($this->once())
+            ->method('isConnected')
+            ->willReturn(false);
+
+        Redis::shouldReceive('connection')
+            ->with(null)
+            ->andReturn($connectionMock);
+        $this->assertFalse($check->check([]));
+        $this->assertSame('The Redis cache can not be accessed: The default cache is not reachable.', $check->message([]));
+    }
+
+    /** @test */
+    public function it_fails_when_named_connection_does_not_exist()
+    {
+        $config = [
+            'default_connection' => false,
+            'connections' => [
+                'some_connection',
+            ],
+        ];
+
+        $check = app(RedisCanBeAccessed::class);
+        $this->assertFalse($check->check($config));
+
+        /** @var MockObject|Connection $connectionMock */
+        $connectionMock = $this->getMockBuilder(Connection::class)
+            ->setMethods(['connect', 'isConnected', 'createSubscription']) // we have to declare the abstract method createSubscription
+            ->getMock();
+        $connectionMock->expects($this->once())
+            ->method('connect');
+        $connectionMock->expects($this->once())
+            ->method('isConnected')
+            ->willReturn(false);
+
+        Redis::shouldReceive('connection')
+            ->with('some_connection')
+            ->andReturn($connectionMock);
+        $this->assertFalse($check->check($config));
+        $this->assertSame('The Redis cache can not be accessed: The named cache some_connection is not reachable.', $check->message($config));
     }
 }

--- a/translations/de/checks.php
+++ b/translations/de/checks.php
@@ -74,7 +74,11 @@ return [
         'name' => 'Die benötigten PHP Erweiterungen sind installiert',
     ],
     'redis_can_be_accessed' => [
-        'message' => 'Auf den Redis Cache kann nicht zugegriffen werden: :error',
+        'message' => [
+            'not_accessible' => 'Auf den Redis Cache kann nicht zugegriffen werden: :error',
+            'default_cache' => 'Der Standard-Cache ist nicht erreichbar.',
+            'named_cache' => 'Der Cache :name ist nicht erreichbar.',
+        ],
         'name' => 'Der Redis Cache ist erreichbar',
     ],
     'routes_are_cached' => [

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -74,7 +74,11 @@ return [
         'name' => 'The required PHP extensions are installed',
     ],
     'redis_can_be_accessed' => [
-        'message' => 'The Redis cache can not be accessed: :error',
+        'message' => [
+            'not_accessible' => 'The Redis cache can not be accessed: :error',
+            'default_cache' => 'The default cache is not reachable.',
+            'named_cache' => 'The named cache :name is not reachable.',
+        ],
         'name' => 'The Redis cache can be accessed',
     ],
     'routes_are_cached' => [


### PR DESCRIPTION
This is only a small PR that hopefully fixes inconsistent check results of the `RedisCanBeAccessed` check. When I tested the foundation for this test, `Redis::connection($name)`, it seemed to already return a connected connection. But my recent tests do not really confirm this. So I made the check a bit more expressive by explicitely connecting to the redis server.

I also added some additional test cases and additional error messages (also for better testability).