### PR TITLE
Fix RedisCanBeAccessed check

### DIFF
--- a/src/Checks/RedisCanBeAccessed.php
+++ b/src/Checks/RedisCanBeAccessed.php
@@ -29,13 +29,17 @@ class RedisCanBeAccessed implements Check
     {
         try {
             if (array_get($config, 'default_connection', true)) {
-                if (!Redis::connection()->isConnected()) {
+                Redis::connection()->connect();
+
+                if (! Redis::connection()->isConnected()) {
                     return false;
                 }
             }
 
             foreach (array_get($config, 'connections', []) as $connection) {
-                if (!Redis::connection($connection)->isConnected()) {
+                Redis::connection($connection)->connect();
+
+                if (! Redis::connection($connection)->isConnected()) {
                     return false;
                 }
             }


### PR DESCRIPTION
`Redis::connection()->isConnected()` always returns `false` if previously application didn't connect to it.
Try to connect at first in `RedisCanBeAccessed` before check by `isConnected()` method.

**Tested on Ubuntu**: http://prntscr.com/k97e9b
**Tested on Mac**: http://prntscr.com/k97eoi

Also it works if you try to get some key value: http://prntscr.com/k97j2a