### PR TITLE
Add option to ignore composer config platform extensions

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -48,6 +48,7 @@ return [
                 'json',
             ],
             'include_composer_extensions' => true,
+            'ignore_composer_config_platform_extensions' => false,
         ],
         //\BeyondCode\SelfDiagnosis\Checks\RedisCanBeAccessed::class => [
         //    'default_connection' => true,

--- a/src/Checks/PhpExtensionsAreInstalled.php
+++ b/src/Checks/PhpExtensionsAreInstalled.php
@@ -56,6 +56,14 @@ class PhpExtensionsAreInstalled implements Check
         $this->extensions = Collection::make(array_get($config, 'extensions', []));
         if (array_get($config, 'include_composer_extensions', false)) {
             $this->extensions = $this->extensions->merge($this->getExtensionsRequiredInComposerFile());
+            if (array_get($config, 'ignore_composer_config_platform_extensions', false)) {
+                $composer_json = json_decode($this->filesystem->get(base_path('composer.json')), true);
+                $ignoreExtentions = collect(array_keys(array_get($composer_json, "config.platform", [])))
+                    ->transform(function ($item) {
+                        return str_replace_first(self::EXT, '', $item);
+                    });
+                $this->extensions = $this->extensions->diff($ignoreExtentions);
+            }
             $this->extensions = $this->extensions->unique();
         }
         $this->extensions = $this->extensions->reject(function ($ext) {

--- a/tests/IgnoreComposerConfigPlatformExtensionsTest.php
+++ b/tests/IgnoreComposerConfigPlatformExtensionsTest.php
@@ -1,0 +1,22 @@
+<?php
+    
+    namespace Tests\Unit;
+
+    use Orchestra\Testbench\TestCase;
+    
+    class IgnoreComposerConfigPlatformExtensionsTest extends TestCase
+    {
+        /** @test */
+        public function it_checks_if_config_platform_extensions_are_ignored()
+        {
+            $check = app(\BeyondCode\SelfDiagnosis\Checks\PhpExtensionsAreInstalled::class);
+            $this->assertFalse($check->check([
+                'include_composer_extensions' => true,
+                'ignore_composer_config_platform_extensions' => false,
+            ]));
+            $this->assertTrue($check->check([
+                'include_composer_extensions' => true,
+                'ignore_composer_config_platform_extensions' => true,
+            ]));
+        }
+    }

--- a/tests/fixtures/composer.json
+++ b/tests/fixtures/composer.json
@@ -54,7 +54,12 @@
   "config": {
     "preferred-install": "dist",
     "sort-packages": true,
-    "optimize-autoloader": true
+    "optimize-autoloader": true,
+
+    "platform":{
+      "ext-pcntl": "7.1",
+      "ext-posix": "1.0"
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true


### PR DESCRIPTION
This package is awesome! Thanks so much.

I hit a snag with Horizon, which requires the ext-pcntl and ext-posix php extensions. My dev environment is Windows and my production environment is Linux. These extensions are unfortunately not available for Windows. The solution I found was to add the following to composer.json
```
  "config": {
    "platform":{
      "ext-pcntl": "7.1",
      "ext-posix": "1.0"
    }
  },
```
It works great. However, after installing laravel-self-diagnosis and running ```php artisan self-diagnosis``` the missing extensions came back to haunt me and fail the laravel-self-diagnosis required PHP extensions check.

This PR tells laravel-self-diagnosis to skip over any extensions listed in composer.json under config['platform']

You can toggle the setting in the config file under ```checks.ignore_composer_config_platform_extensions```