### PR TITLE
Remove not allowed attributs from phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>


### PR DESCRIPTION
If I run phpunit with the current phpunit.xml.dist I get the next result:

```
Configuration: /var/www/laravel-self-diagnosis/phpunit.xml.dist

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 25:
  - Element 'log', attribute 'charset': The attribute 'charset' is not allowed.
  - Element 'log', attribute 'yui': The attribute 'yui' is not allowed.
  - Element 'log', attribute 'highlight': The attribute 'highlight' is not allowed.

  Test results may not be as expected.
```

This pr removes the attributes that are reported as not allowed. If they have a reason to be there, I like to learn it.