### PR TITLE
Add local/dev check: ExampleEnvironmentVariablesAreUpToDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Here is an example output of the command:
 
 - Is the configuration not cached?
 - Are the routes not cached?
+- Are there environment variables that exist in `.env` but not in `.env.example`?
 
 ### Production environment checks
 
@@ -49,7 +50,7 @@ You can install the package via composer:
 composer require beyondcode/laravel-self-diagnosis
 ```
 
-If you're using Laravel 5.5+ the `SelfDiagnosisServiceProvider` will be automatically registered for you. 
+If you're using Laravel 5.5+ the `SelfDiagnosisServiceProvider` will be automatically registered for you.
 
 ## Usage
 
@@ -247,7 +248,7 @@ class MyCustomCheck implements Check
 }
 ```
 
- 
+
 ### Example Output
 
 

--- a/config/config.php
+++ b/config/config.php
@@ -64,6 +64,7 @@ return [
             \BeyondCode\SelfDiagnosis\Checks\ComposerWithDevDependenciesIsUpToDate::class,
             \BeyondCode\SelfDiagnosis\Checks\ConfigurationIsNotCached::class,
             \BeyondCode\SelfDiagnosis\Checks\RoutesAreNotCached::class,
+            \BeyondCode\SelfDiagnosis\Checks\ExampleEnvironmentVariablesAreUpToDate::class,
         ],
         'production' => [
             \BeyondCode\SelfDiagnosis\Checks\ComposerWithoutDevDependenciesIsUpToDate::class,

--- a/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Checks;
+
+use Dotenv\Dotenv;
+use Illuminate\Support\Collection;
+
+class ExampleEnvironmentVariablesAreUpToDate implements Check
+{
+    /** @var Collection */
+    private $envVariables;
+
+    /**
+     * The name of the check.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function name(array $config): string
+    {
+        return trans('self-diagnosis::checks.example_environment_variables_are_up_to_date.name');
+    }
+
+    /**
+     * Perform the actual verification of this check.
+     *
+     * @param array $config
+     * @return bool
+     */
+    public function check(array $config): bool
+    {
+        $examples = new Dotenv(base_path(), '.env.example');
+        $examples->safeLoad();
+
+        $actual = new Dotenv(base_path(), '.env');
+        $actual->safeLoad();
+
+        $this->envVariables = Collection::make($actual->getEnvironmentVariableNames())
+            ->diff($examples->getEnvironmentVariableNames());
+
+        return $this->envVariables->isEmpty();
+    }
+
+    /**
+     * The error message to display in case the check does not pass.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function message(array $config): string
+    {
+        return trans('self-diagnosis::checks.example_environment_variables_are_up_to_date.message', [
+            'variables' => $this->envVariables->implode(PHP_EOL),
+        ]);
+    }
+}

--- a/tests/ExampleEnvironmentVariablesAreUpToDateTest.php
+++ b/tests/ExampleEnvironmentVariablesAreUpToDateTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Tests;
+
+use Orchestra\Testbench\TestCase;
+use BeyondCode\SelfDiagnosis\SelfDiagnosisServiceProvider;
+use BeyondCode\SelfDiagnosis\Checks\ExampleEnvironmentVariablesAreUpToDate;
+
+class ExampleEnvironmentVariablesAreUpToDateTest extends TestCase
+{
+    public function getPackageProviders($app)
+    {
+        return [
+            SelfDiagnosisServiceProvider::class,
+        ];
+    }
+
+    /** @test */
+    public function it_checks_if_example_env_variables_are_set_in_env_file()
+    {
+        $this->app->setBasePath(__DIR__ . '/fixtures');
+
+        $check = new ExampleEnvironmentVariablesAreUpToDate();
+
+        $this->assertFalse($check->check([]));
+        $this->assertSame('These environment variables are defined in your .env file, but are missing in your .env.example:'.PHP_EOL.'KEY_FOUR', $check->message([]));
+    }
+}

--- a/tests/fixtures/.env
+++ b/tests/fixtures/.env
@@ -1,2 +1,3 @@
 KEY_ONE=foo
 KEY_THREE=
+KEY_FOUR=bar

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -45,6 +45,10 @@ return [
         'message' => 'These environment variables are missing in your .env file, but are defined in your .env.example:' . PHP_EOL . ':variables',
         'name' => 'The example environment variables are set',
     ],
+    'example_environment_variables_are_up_to_date' => [
+        'message' => 'These environment variables are defined in your .env file, but are missing in your .env.example:' . PHP_EOL . ':variables',
+        'name' => 'The example environment variables are up-to-date',
+    ],
     'locales_are_installed' => [
         'message' => [
             'cannot_run_on_windows' => 'This check cannot be run on Windows.',


### PR DESCRIPTION
Adds a new local/development check to ensure that all `.env` variables have been added to `.env.example`. I think this will be useful to make sure that variables I add during development are properly "documented" into the `.env.example`.

The code is nearly identical to the current check that looks for `.env.example` variables that are missing from `.env`. Also, I only added English translations because I don't know German. 😄 
