### PR TITLE
Fix the PHP version check with the use of Semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "composer/semver": "^1.4",
         "geerlingguy/ping": "^1.1",
         "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
         "vlucas/phpdotenv": "~2.5"

--- a/src/Checks/CorrectPhpVersionIsInstalled.php
+++ b/src/Checks/CorrectPhpVersionIsInstalled.php
@@ -62,18 +62,6 @@ class CorrectPhpVersionIsInstalled implements Check
      * @return mixed
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function getRequiredPhpVersion()
-    {
-        $composer = json_decode($this->filesystem->get(base_path('composer.json')), true);
-        $versionString = array_get($composer, 'require.php');
-
-        return str_replace(['^', '~', '<', '>', '='], '', $versionString);
-    }
-
-    /**
-     * @return mixed
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
-     */
     public function getRequiredPhpConstraint()
     {
         $composer = json_decode($this->filesystem->get(base_path('composer.json')), true);

--- a/tests/CorrectPhpVersionIsInstalledTest.php
+++ b/tests/CorrectPhpVersionIsInstalledTest.php
@@ -9,16 +9,6 @@ use Illuminate\Filesystem\Filesystem;
 class CorrectPhpVersionIsInstalledTest extends TestCase
 {
     /** @test */
-    public function it_detects_the_php_version_from_composer_json()
-    {
-        $this->app->setBasePath(__DIR__ . '/fixtures');
-
-        $check = app(CorrectPhpVersionIsInstalled::class);
-
-        $this->assertSame('7.1.3', $check->getRequiredPhpVersion());
-    }
-
-    /** @test */
     public function it_detects_the_php_constraint_from_composer_json()
     {
         $this->app->setBasePath(__DIR__ . '/fixtures');

--- a/tests/CorrectPhpVersionIsInstalledTest.php
+++ b/tests/CorrectPhpVersionIsInstalledTest.php
@@ -4,6 +4,7 @@ namespace BeyondCode\SelfDiagnosis\Tests;
 
 use Orchestra\Testbench\TestCase;
 use BeyondCode\SelfDiagnosis\Checks\CorrectPhpVersionIsInstalled;
+use Illuminate\Filesystem\Filesystem;
 
 class CorrectPhpVersionIsInstalledTest extends TestCase
 {
@@ -15,5 +16,67 @@ class CorrectPhpVersionIsInstalledTest extends TestCase
         $check = app(CorrectPhpVersionIsInstalled::class);
 
         $this->assertSame('7.1.3', $check->getRequiredPhpVersion());
+    }
+
+    /** @test */
+    public function it_detects_the_php_constraint_from_composer_json()
+    {
+        $this->app->setBasePath(__DIR__ . '/fixtures');
+
+        $check = app(CorrectPhpVersionIsInstalled::class);
+
+        $this->assertSame('^7.1.3', $check->getRequiredPhpConstraint());
+    }
+
+    /** @test */
+    public function it_detects_php_version_to_low()
+    {
+
+        $fileSystemMock = \Mockery::mock(Filesystem::class);
+
+        $data = file_get_contents(__DIR__ . '/fixtures/composer.json');
+
+        $data = str_replace('"php": "^7.1.3",', '"php": "^100",', $data);
+
+        $fileSystemMock->shouldReceive('get')
+            ->andReturn($data);
+
+        $check = new CorrectPhpVersionIsInstalled($fileSystemMock);
+
+        $this->assertFalse($check->check([]));
+    }
+
+    /** @test */
+    public function it_detects_php_version_to_high()
+    {
+        $fileSystemMock = \Mockery::mock(Filesystem::class);
+
+        $data = file_get_contents(__DIR__ . '/fixtures/composer.json');
+
+        $data = str_replace('"php": "^7.1.3",', '"php": "<=1",', $data);
+
+        $fileSystemMock->shouldReceive('get')
+            ->andReturn($data);
+
+        $check = new CorrectPhpVersionIsInstalled($fileSystemMock);
+
+        $this->assertFalse($check->check([]));
+    }
+
+    /** @test */
+    public function it_accepts_version_with_asterix()
+    {
+        $fileSystemMock = \Mockery::mock(Filesystem::class);
+
+        $data = file_get_contents(__DIR__ . '/fixtures/composer.json');
+
+        $data = str_replace('"php": "^7.1.3",', '"php": "7.*",', $data);
+
+        $fileSystemMock->shouldReceive('get')
+            ->andReturn($data);
+
+        $check = new CorrectPhpVersionIsInstalled($fileSystemMock);
+
+        $this->assertTrue($check->check([]));
     }
 }


### PR DESCRIPTION
The current check only takes the PHP version from the composer.json file and checks if the current version is the same or higher. But composer has more options, that if used can be conflicted or incorrect tested. See: https://getcomposer.org/doc/articles/versions.md#summary

I have changed the behaviour by using the Semver package from composer to check it.

The only question I have is the change on the getRequiredPhpVersion function. Because it is a public function I didn't want to change it and added a new function getRequiredPhpConstraint. That means that there is now a function that isn't used by the check. If wanted I can mark it as deprecated