### PR TITLE
Add ocular for scrutinizer and configure for remote code coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,3 +17,7 @@ checks:
         fix_identation_4spaces: true
         fix_doc_comments: true
 
+tools:
+    external_code_coverage:
+        timeout: 600
+        runs: 4

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,12 @@
         "vlucas/phpdotenv": "~2.5"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
         "larapack/dd": "^1.0",
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "~3.5",
         "phpunit/phpunit": "^7.0",
-        "predis/predis": "^1.1"
+        "predis/predis": "^1.1",
+        "scrutinizer/ocular": "^1.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I was interested in the scrutinizer status for this project and find out the code coverage didn't work.

I found out that the travis job try to call vendor/bin/ocular but that didn't exist. And I read in https://scrutinizer-ci.com/docs/tools/external-code-coverage/ that the .scrutinizer.yml need some addition. So that are the changes I did in this PR.