### PR TITLE
Replace array_* with Arr::* for 5.8 support

### DIFF
--- a/src/Checks/ComposerWithDevDependenciesIsUpToDate.php
+++ b/src/Checks/ComposerWithDevDependenciesIsUpToDate.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\SelfDiagnosis\Checks;
 
 use BeyondCode\SelfDiagnosis\Composer;
+use Illuminate\Support\Arr;
 
 class ComposerWithDevDependenciesIsUpToDate implements Check
 {
@@ -37,7 +38,7 @@ class ComposerWithDevDependenciesIsUpToDate implements Check
      */
     public function check(array $config): bool
     {
-        $additionalOptions = array_get($config, 'additional_options', '');
+        $additionalOptions = Arr::get($config, 'additional_options', '');
 
         $this->output = $this->composer->installDryRun($additionalOptions);
 

--- a/src/Checks/ComposerWithoutDevDependenciesIsUpToDate.php
+++ b/src/Checks/ComposerWithoutDevDependenciesIsUpToDate.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\SelfDiagnosis\Checks;
 
 use BeyondCode\SelfDiagnosis\Composer;
+use Illuminate\Support\Arr;
 
 class ComposerWithoutDevDependenciesIsUpToDate implements Check
 {
@@ -37,7 +38,7 @@ class ComposerWithoutDevDependenciesIsUpToDate implements Check
      */
     public function check(array $config): bool
     {
-        $additionalOptions = array_get($config, 'additional_options', '');
+        $additionalOptions = Arr::get($config, 'additional_options', '');
 
         $this->output = $this->composer->installDryRun('--no-dev ' . $additionalOptions);
 

--- a/src/Checks/CorrectPhpVersionIsInstalled.php
+++ b/src/Checks/CorrectPhpVersionIsInstalled.php
@@ -4,6 +4,7 @@ namespace BeyondCode\SelfDiagnosis\Checks;
 
 use Illuminate\Filesystem\Filesystem;
 use Composer\Semver\Semver;
+use Illuminate\Support\Arr;
 
 class CorrectPhpVersionIsInstalled implements Check
 {
@@ -65,6 +66,6 @@ class CorrectPhpVersionIsInstalled implements Check
     public function getRequiredPhpConstraint()
     {
         $composer = json_decode($this->filesystem->get(base_path('composer.json')), true);
-        return array_get($composer, 'require.php');
+        return Arr::get($composer, 'require.php');
     }
 }

--- a/src/Checks/DatabaseCanBeAccessed.php
+++ b/src/Checks/DatabaseCanBeAccessed.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\SelfDiagnosis\Checks;
 
 use DB;
+use Illuminate\Support\Arr;
 
 class DatabaseCanBeAccessed implements Check
 {
@@ -28,11 +29,11 @@ class DatabaseCanBeAccessed implements Check
     public function check(array $config): bool
     {
         try {
-            if (array_get($config, 'default_connection', true)) {
+            if (Arr::get($config, 'default_connection', true)) {
                 DB::connection()->getPdo();
             }
 
-            foreach (array_get($config, 'connections', []) as $connection) {
+            foreach (Arr::get($config, 'connections', []) as $connection) {
                 DB::connection($connection)->getPdo();
             }
 

--- a/src/Checks/DirectoriesHaveCorrectPermissions.php
+++ b/src/Checks/DirectoriesHaveCorrectPermissions.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\SelfDiagnosis\Checks;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;
 
@@ -54,7 +55,7 @@ class DirectoriesHaveCorrectPermissions implements Check
      */
     public function check(array $config): bool
     {
-        $this->paths = Collection::make(array_get($config, 'directories', []));
+        $this->paths = Collection::make(Arr::get($config, 'directories', []));
 
         $this->paths = $this->paths->reject(function ($path) {
             return $this->filesystem->isWritable($path);

--- a/src/Checks/LocalesAreInstalled.php
+++ b/src/Checks/LocalesAreInstalled.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\SelfDiagnosis\Checks;
 
 use BeyondCode\SelfDiagnosis\SystemFunctions;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 class LocalesAreInstalled implements Check
@@ -45,7 +46,7 @@ class LocalesAreInstalled implements Check
      */
     public function check(array $config): bool
     {
-        $this->missingLocales = new Collection(array_get($config, 'required_locales', []));
+        $this->missingLocales = new Collection(Arr::get($config, 'required_locales', []));
         if ($this->missingLocales->isEmpty()) {
             return true;
         }

--- a/src/Checks/PhpExtensionsAreDisabled.php
+++ b/src/Checks/PhpExtensionsAreDisabled.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\SelfDiagnosis\Checks;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 class PhpExtensionsAreDisabled implements Check
@@ -29,7 +30,7 @@ class PhpExtensionsAreDisabled implements Check
      */
     public function check(array $config): bool
     {
-        $this->extensions = Collection::make(array_get($config, 'extensions', []));
+        $this->extensions = Collection::make(Arr::get($config, 'extensions', []));
         $this->extensions = $this->extensions->reject(function ($ext) {
             return extension_loaded($ext) === false;
         });

--- a/src/Checks/PhpExtensionsAreInstalled.php
+++ b/src/Checks/PhpExtensionsAreInstalled.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\SelfDiagnosis\Checks;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 class PhpExtensionsAreInstalled implements Check
@@ -53,8 +54,8 @@ class PhpExtensionsAreInstalled implements Check
      */
     public function check(array $config): bool
     {
-        $this->extensions = Collection::make(array_get($config, 'extensions', []));
-        if (array_get($config, 'include_composer_extensions', false)) {
+        $this->extensions = Collection::make(Arr::get($config, 'extensions', []));
+        if (Arr::get($config, 'include_composer_extensions', false)) {
             $this->extensions = $this->extensions->merge($this->getExtensionsRequiredInComposerFile());
             $this->extensions = $this->extensions->unique();
         }
@@ -75,7 +76,7 @@ class PhpExtensionsAreInstalled implements Check
 
         $extensions = [];
         foreach ($installedPackages as $installedPackage) {
-            $filtered = array_where(array_keys(array_get($installedPackage, 'require', [])), function ($value, $key) {
+            $filtered = Arr::where(array_keys(Arr::get($installedPackage, 'require', [])), function ($value, $key) {
                 return starts_with($value, self::EXT);
             });
             foreach ($filtered as $extension) {

--- a/src/Checks/RedisCanBeAccessed.php
+++ b/src/Checks/RedisCanBeAccessed.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\SelfDiagnosis\Checks;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Redis;
 
 class RedisCanBeAccessed implements Check
@@ -28,14 +29,14 @@ class RedisCanBeAccessed implements Check
     public function check(array $config): bool
     {
         try {
-            if (array_get($config, 'default_connection', true)) {
+            if (Arr::get($config, 'default_connection', true)) {
                 if (!$this->testConnection()) {
                     $this->message = trans('self-diagnosis::checks.redis_can_be_accessed.message.default_cache');
                     return false;
                 }
             }
 
-            foreach (array_get($config, 'connections', []) as $connection) {
+            foreach (Arr::get($config, 'connections', []) as $connection) {
                 if (!$this->testConnection($connection)) {
                     $this->message = trans('self-diagnosis::checks.redis_can_be_accessed.message.named_cache', [
                         'name' => $connection,

--- a/src/Checks/ServersArePingable.php
+++ b/src/Checks/ServersArePingable.php
@@ -4,6 +4,7 @@ namespace BeyondCode\SelfDiagnosis\Checks;
 
 use BeyondCode\SelfDiagnosis\Exceptions\InvalidConfigurationException;
 use BeyondCode\SelfDiagnosis\Server;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use JJG\Ping;
 
@@ -34,7 +35,7 @@ class ServersArePingable implements Check
      */
     public function check(array $config): bool
     {
-        $this->notReachableServers = $this->parseConfiguredServers(array_get($config, 'servers', []));
+        $this->notReachableServers = $this->parseConfiguredServers(Arr::get($config, 'servers', []));
         if ($this->notReachableServers->isEmpty()) {
             return true;
         }
@@ -94,9 +95,9 @@ class ServersArePingable implements Check
                     throw new InvalidConfigurationException('For servers in array notation, the host parameter is required.');
                 }
 
-                $host = array_get($server, 'host');
-                $port = array_get($server, 'port');
-                $timeout = array_get($server, 'timeout', self::DEFAULT_TIMEOUT);
+                $host = Arr::get($server, 'host');
+                $port = Arr::get($server, 'port');
+                $timeout = Arr::get($server, 'timeout', self::DEFAULT_TIMEOUT);
 
                 $result->push(new Server($host, $port, $timeout));
             } else if (is_string($server)) {

--- a/src/Checks/SupervisorProgramsAreRunning.php
+++ b/src/Checks/SupervisorProgramsAreRunning.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\SelfDiagnosis\Checks;
 
 use BeyondCode\SelfDiagnosis\SystemFunctions;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 class SupervisorProgramsAreRunning implements Check
@@ -48,7 +49,7 @@ class SupervisorProgramsAreRunning implements Check
      */
     public function check(array $config): bool
     {
-        $this->notRunningPrograms = new Collection(array_get($config, 'programs', []));
+        $this->notRunningPrograms = new Collection(Arr::get($config, 'programs', []));
         if ($this->notRunningPrograms->isEmpty()) {
             return true;
         }
@@ -69,7 +70,7 @@ class SupervisorProgramsAreRunning implements Check
             return false;
         }
 
-        $restartedWithin = array_get($config, 'restarted_within', 0);
+        $restartedWithin = Arr::get($config, 'restarted_within', 0);
         $programs = explode("\n" , $programs);
         foreach ($programs as $program) {
             /*


### PR DESCRIPTION
Replaced usage of array_& helpers with Arr::* for Laravel 5.8/9 support.
https://laravel.com/docs/master/upgrade#string-and-array-helpers