### PR TITLE
Upgrade dotenv to v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,13 @@
         "composer/semver": "^1.4",
         "geerlingguy/ping": "^1.1",
         "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
-        "vlucas/phpdotenv": "~2.5"
+        "vlucas/phpdotenv": "^3.3"
     },
     "require-dev": {
         "larapack/dd": "^1.0",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "~3.5",
+        "orchestra/testbench": "^3.8",
+        "orchestra/testbench-core": "3.8.x-dev",
         "phpunit/phpunit": "^7.0",
         "predis/predis": "^1.1",
         "scrutinizer/ocular": "^1.5"
@@ -43,7 +44,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         "composer/semver": "^1.4",
         "geerlingguy/ping": "^1.1",
         "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
-        "vlucas/phpdotenv": "^2.5|^3.3"
+        "vlucas/phpdotenv": "~2.5|~3.3"
     },
     "require-dev": {
         "larapack/dd": "^1.0",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^3.8",
+        "orchestra/testbench": "~3.5|~3.8",
         "phpunit/phpunit": "^7.0",
         "predis/predis": "^1.1",
         "scrutinizer/ocular": "^1.5"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "larapack/dd": "^1.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^3.8",
-        "orchestra/testbench-core": "3.8.x-dev",
         "phpunit/phpunit": "^7.0",
         "predis/predis": "^1.1",
         "scrutinizer/ocular": "^1.5"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "composer/semver": "^1.4",
         "geerlingguy/ping": "^1.1",
         "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
-        "vlucas/phpdotenv": "^3.3"
+        "vlucas/phpdotenv": "^2.5|^3.3"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/src/Checks/ExampleEnvironmentVariablesAreSet.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreSet.php
@@ -29,10 +29,15 @@ class ExampleEnvironmentVariablesAreSet implements Check
      */
     public function check(array $config): bool
     {
-        $examples = Dotenv::create(base_path(), '.env.example');
-        $examples->safeLoad();
+        if (interface_exists(\Dotenv\Environment\FactoryInterface::class)) {
+            $examples = Dotenv::create(base_path(), '.env.example');
+            $actual = Dotenv::create(base_path(), '.env');
+        } else {
+            $examples = new Dotenv(base_path(), '.env.example');
+            $actual = new Dotenv(base_path(), '.env');
+        }
 
-        $actual = Dotenv::create(base_path(), '.env');
+        $examples->safeLoad();
         $actual->safeLoad();
 
         $this->envVariables = Collection::make($examples->getEnvironmentVariableNames())

--- a/src/Checks/ExampleEnvironmentVariablesAreSet.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreSet.php
@@ -29,10 +29,10 @@ class ExampleEnvironmentVariablesAreSet implements Check
      */
     public function check(array $config): bool
     {
-        $examples = new Dotenv(base_path(), '.env.example');
+        $examples = Dotenv::create(base_path(), '.env.example');
         $examples->safeLoad();
 
-        $actual = new Dotenv(base_path(), '.env');
+        $actual = Dotenv::create(base_path(), '.env');
         $actual->safeLoad();
 
         $this->envVariables = Collection::make($examples->getEnvironmentVariableNames())

--- a/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
@@ -29,10 +29,15 @@ class ExampleEnvironmentVariablesAreUpToDate implements Check
      */
     public function check(array $config): bool
     {
-        $examples = Dotenv::create(base_path(), '.env.example');
-        $examples->safeLoad();
+        if (interface_exists(\Dotenv\Environment\FactoryInterface::class)) {
+            $examples = Dotenv::create(base_path(), '.env.example');
+            $actual = Dotenv::create(base_path(), '.env');
+        } else {
+            $examples = new Dotenv(base_path(), '.env.example');
+            $actual = new Dotenv(base_path(), '.env');
+        }
 
-        $actual = Dotenv::create(base_path(), '.env');
+        $examples->safeLoad();
         $actual->safeLoad();
 
         $this->envVariables = Collection::make($actual->getEnvironmentVariableNames())

--- a/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
@@ -29,10 +29,10 @@ class ExampleEnvironmentVariablesAreUpToDate implements Check
      */
     public function check(array $config): bool
     {
-        $examples = new Dotenv(base_path(), '.env.example');
+        $examples = Dotenv::create(base_path(), '.env.example');
         $examples->safeLoad();
 
-        $actual = new Dotenv(base_path(), '.env');
+        $actual = Dotenv::create(base_path(), '.env');
         $actual->safeLoad();
 
         $this->envVariables = Collection::make($actual->getEnvironmentVariableNames())


### PR DESCRIPTION
There's an incompatibility with Laravel 5.8 and this because of `vlucas/phpdotenv` between each's composer.json.

| Project                             | Dependency         | Version |
|-------------------------------------|--------------------|---------|
| `laravel/framework`                 | `vlucas/phpdotenv` | ^3.3    |
| `beyondcode/laravel-self-diagnosis` | `vlucas/phpdotenv` | ~2.5    |

I know this PR's current state is not the best way to fix it (unless you want to release a new major version), as it will break backwards compatibility, but here's a first attempt to hopefully help at least get it started. This fixes it for 5.8.