### PR TITLE
Update Composer checks to work with Laravel 5.8

### DIFF
--- a/src/Composer.php
+++ b/src/Composer.php
@@ -6,9 +6,20 @@ class Composer extends \Illuminate\Support\Composer
 {
     public function installDryRun(string $options = null)
     {
-        $process = $this->getProcess();
+        $composer = $this->findComposer();
 
-        $process->setCommandLine(trim($this->findComposer().' install --dry-run '.$options));
+        $command = array_merge(
+            (array) $composer,
+            ['install', '--dry-run'],
+            array_filter(array_map('trim', explode(' ', $options)))
+        );
+
+        if (is_array($composer)) {
+            $process = $this->getProcess($command);
+        } else {
+            $process = $this->getProcess();
+            $process->setCommandLine(trim(implode(' ', $command)));
+        }
 
         $process->run();
 


### PR DESCRIPTION
In Laravel 5.8, `Composer::getProcess()` now requires the `$command` passed to it as an array.

Also in 5.8, `Composer::findComposer()` now returns an array instead of a string. So I'm using that to determine which `->getProcess()` is called. Should be compatible with 5.7.

Change commit in Laravel: laravel/framework@d1b948103b9933d9881c280df39b289f324bcceb

Fixes #75, ping @kbond