### PR TITLE
Making command environment more flexible

### DIFF
--- a/src/SelfDiagnosisCommand.php
+++ b/src/SelfDiagnosisCommand.php
@@ -12,7 +12,7 @@ class SelfDiagnosisCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'self-diagnosis';
+    protected $signature = 'self-diagnosis {environment?}';
 
     /**
      * The console command description.
@@ -27,13 +27,15 @@ class SelfDiagnosisCommand extends Command
     {
         $this->runChecks(config('self-diagnosis.checks', []), trans('self-diagnosis::commands.self_diagnosis.common_checks'));
 
-        $environmentChecks = config('self-diagnosis.environment_checks.' . app()->environment(), []);
-        if (empty($environmentChecks) && array_key_exists(app()->environment(), config('self-diagnosis.environment_aliases'))) {
-            $environment = config('self-diagnosis.environment_aliases.' . app()->environment());
+        $environment = $this->argument('environment', app()->environment());
+        $environmentChecks = config('self-diagnosis.environment_checks.' . $environment, []);
+
+        if (empty($environmentChecks) && array_key_exists($environment, config('self-diagnosis.environment_aliases'))) {
+            $environment = config('self-diagnosis.environment_aliases.' . $environment);
             $environmentChecks = config('self-diagnosis.environment_checks.' . $environment, []);
         }
 
-        $this->runChecks($environmentChecks, trans('self-diagnosis::commands.self_diagnosis.environment_specific_checks', ['environment' => app()->environment()]));
+        $this->runChecks($environmentChecks, trans('self-diagnosis::commands.self_diagnosis.environment_specific_checks', ['environment' => $environment]));
 
         if (count($this->messages)) {
             $this->error(trans('self-diagnosis::commands.self_diagnosis.failed_checks'));


### PR DESCRIPTION
Currently `php artisan self-diagnosis` totally relies on `APP_ENV`, with this change it will continue to rely on it but now you can run `php artisan self-diagnosis something_else` and this argument will be use for the checks instead of `APP_ENV`.

My use case:

I want to run separate checks on separate servers, like:

```
php artisan self-diagnosis web
php artisan self-diagnosis worker
```

Both servers are `APP_ENV=production`, i just want to run different checks.

But you want still run just based on your `APP_ENV`:

```
php artisan self-diagnosis
```