### PR TITLE
Adding Horizon Is Running Check

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -90,6 +90,7 @@ return [
             //    ],
             //    'restarted_within' => 300,
             //],
+            //\BeyondCode\SelfDiagnosis\Checks\HorizonIsRunning::class,
         ],
     ],
 

--- a/src/Checks/HorizonIsRunning.php
+++ b/src/Checks/HorizonIsRunning.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Checks;
+
+use BeyondCode\SelfDiagnosis\Checks\Check;
+use Illuminate\Support\Facades\Artisan;
+
+class HorizonIsRunning implements Check
+{
+    private $error = null;
+
+    /**
+     * The name of the check.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function name(array $config): string
+    {
+        return trans('self-diagnosis::checks.horizon_is_running.name');
+    }
+
+    /**
+     * Perform the actual verification of this check.
+     *
+     * @param array $config
+     * @return bool
+     */
+    public function check(array $config): bool
+    {
+        try {
+            Artisan::call('horizon:status');
+            $output = Artisan::output();
+
+            return strstr($output, 'Horizon is running.');
+        } catch (\Exception $e) {
+            $this->error = $e->getMessage();
+        }
+
+        return false;
+    }
+
+    /**
+     * The error message to display in case the check does not pass.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function message(array $config): string
+    {
+        if ($this->error !== null) {
+            return trans('self-diagnosis::checks.horizon_is_running.message.unable_to_check', [
+                'reason' => $this->error,
+            ]);
+        }
+
+        return trans('self-diagnosis::checks.horizon_is_running.message.not_running');
+    }
+}

--- a/tests/HorizonIsRunningTest.php
+++ b/tests/HorizonIsRunningTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Tests;
+
+use Illuminate\Support\Facades\Artisan;
+use Orchestra\Testbench\TestCase;
+use BeyondCode\SelfDiagnosis\Checks\HorizonIsRunning;
+
+class HorizonIsRunningTest extends TestCase
+{
+    /** @test */
+    public function it_succeeds_when_horizon_is_running()
+    {
+        $check = new HorizonIsRunning();
+
+        Artisan::shouldReceive('call');
+
+        Artisan::shouldReceive('output')
+            ->andReturn('Horizon is running.');
+
+        $this->assertTrue($check->check([]));
+    }
+
+    /** @test */
+    public function is_fails_when_horizon_is_not_running()
+    {
+        $check = new HorizonIsRunning();
+
+        Artisan::shouldReceive('call');
+
+        Artisan::shouldReceive('output')
+            ->andReturn('Horizon is paused.');
+
+        $this->assertFalse($check->check([]));
+    }
+}

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -49,6 +49,13 @@ return [
         'message' => 'These environment variables are defined in your .env file, but are missing in your .env.example:' . PHP_EOL . ':variables',
         'name' => 'The example environment variables are up-to-date',
     ],
+    'horizon_is_running' => [
+        'message' => [
+            'not_running' => 'Horizon is not running.',
+            'unable_to_check' => 'Unable to check for horizon: :reason',
+        ],
+        'name' => 'Horizon is running',
+    ],
     'locales_are_installed' => [
         'message' => [
             'cannot_run_on_windows' => 'This check cannot be run on Windows.',


### PR DESCRIPTION
A new command was recently introduced at Horizon: https://github.com/laravel/horizon/blob/3.0/src/Console/StatusCommand.php

The new command tests using this new command instead of checking for supervisor.

In my case i have a container running `horizon` at `foreground` so i don't use supervisor... But this may be useful for other people that runs other process managers instead of supervisor.

This also checks if `horizon` is really `running`, if `horizon` is `paused` the process is still there and supervisor check will succeed, this one will fail.