### PR TITLE
Add check: CachePrefixIsSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Here is an example output of the command:
 - Are there any migrations that need to be run?
 - Is the storage directory linked?
 - Can Redis be accessed?
+- Is a CACHE_PREFIX set?
 
 ### Development environment checks
 
@@ -89,6 +90,7 @@ return [
      */
     'checks' => [
         \BeyondCode\SelfDiagnosis\Checks\AppKeyIsSet::class,
+        \BeyondCode\SelfDiagnosis\Checks\CachePrefixIsSet::class,
         \BeyondCode\SelfDiagnosis\Checks\CorrectPhpVersionIsInstalled::class,
         \BeyondCode\SelfDiagnosis\Checks\DatabaseCanBeAccessed::class => [
             'default_connection' => true,

--- a/config/config.php
+++ b/config/config.php
@@ -16,6 +16,7 @@ return [
      */
     'checks' => [
         \BeyondCode\SelfDiagnosis\Checks\AppKeyIsSet::class,
+        \BeyondCode\SelfDiagnosis\Checks\CachePrefixIsSet::class,
         \BeyondCode\SelfDiagnosis\Checks\CorrectPhpVersionIsInstalled::class,
         \BeyondCode\SelfDiagnosis\Checks\DatabaseCanBeAccessed::class => [
             'default_connection' => true,

--- a/src/Checks/CachePrefixIsSet.php
+++ b/src/Checks/CachePrefixIsSet.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Checks;
+
+use Dotenv\Dotenv;
+
+class CachePrefixIsSet implements Check
+{
+    /**
+     * The name of the check.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function name(array $config): string
+    {
+        return trans('self-diagnosis::checks.cache_prefix_is_set.name');
+    }
+
+    /**
+     * Perform the actual verification of this check.
+     *
+     * @param array $config
+     * @return bool
+     */
+    public function check(array $config): bool
+    {
+        if (interface_exists(\Dotenv\Environment\FactoryInterface::class)) {
+            $env = Dotenv::create(base_path(), '.env');
+        } else {
+            $env = new Dotenv(base_path(), '.env');
+        }
+
+        $env->safeLoad();
+
+        return in_array('CACHE_PREFIX', $env->getEnvironmentVariableNames());
+    }
+
+    /**
+     * The error message to display in case the check does not pass.
+     *
+     * @param array $config
+     * @return string
+     */
+    public function message(array $config): string
+    {
+        return trans('self-diagnosis::checks.cache_prefix_is_set.message');
+    }
+}

--- a/tests/CachePrefixIsSetTest.php
+++ b/tests/CachePrefixIsSetTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BeyondCode\SelfDiagnosis\Tests;
+
+use Orchestra\Testbench\TestCase;
+use BeyondCode\SelfDiagnosis\Checks\CachePrefixIsSet;
+use BeyondCode\SelfDiagnosis\SelfDiagnosisServiceProvider;
+
+class CachePrefixIsSetTest extends TestCase
+{
+    public function getPackageProviders($app)
+    {
+        return [
+            SelfDiagnosisServiceProvider::class,
+        ];
+    }
+
+    /** @test */
+    public function it_checks_if_the_cache_prefix_env_variable_is_set_in_the_env_file()
+    {
+        $this->app->setBasePath(__DIR__ . '/fixtures');
+
+        $check = new CachePrefixIsSet();
+
+        $this->assertFalse($check->check([]));
+        $this->assertSame('A missing cache prefix could cause problems in shared hosting environments due to shared cache key access. Set a custom "CACHE_PREFIX" in your .env file.', $check->message([]));
+    }
+}

--- a/translations/de/checks.php
+++ b/translations/de/checks.php
@@ -5,6 +5,10 @@ return [
         'message' => 'Der Anwendungsschlüssel ist nicht gesetzt. Nutze "php artisan key:generate", um einen zu erstellen und zu setzen.',
         'name' => 'Anwendungsschlüssel ist gesetzt',
     ],
+    'cache_prefix_is_set' => [
+        'message' => 'Ein fehlendes Cache-Prefix könnte in Shared-Hosting-Umgebungen Probleme verursachen wegen parallelem Zugriff auf Cache-Schlüssel. Setze ein eigenes "CACHE_PREFIX" in der .env Datei.',
+        'name' => 'Cache prefix ist gesetzt'
+    ],
     'composer_with_dev_dependencies_is_up_to_date' => [
         'message' => 'Die Composer Abhängigkeiten sind nicht aktuell. Nutze "composer install", um diese zu aktualisieren. :more',
         'name' => 'Composer Abhängigkeiten (inkl. dev) sind aktuell',

--- a/translations/en/checks.php
+++ b/translations/en/checks.php
@@ -5,6 +5,10 @@ return [
         'message' => 'The application key is not set. Call "php artisan key:generate" to create and set one.',
         'name' => 'App key is set',
     ],
+    'cache_prefix_is_set' => [
+        'message' => 'A missing cache prefix could cause problems in shared hosting environments due to shared cache key access. Set a custom "CACHE_PREFIX" in your .env file.',
+        'name' => 'Cache prefix is set'
+    ],
     'composer_with_dev_dependencies_is_up_to_date' => [
         'message' => 'Your composer dependencies are not up to date. Call "composer install" to update them. :more',
         'name' => 'Composer dependencies (including dev) are up to date',


### PR DESCRIPTION
When an in-memory caching is used in a shared hosting environment (e.g. because there's an additional staging system on the same server) and no cache prefix is set and Laravel sites have the same app name configured, Laravel will fall back to a default cache key prefix which leads to shared cache key access across sites.

I'm sorry, I have no idea why the language files are completely rewritten in the commit. Of course I just added the relevant lines and that's also what ```git diff``` indicated.