### PR TITLE
Add correct locale for macOS. Related to issue #64

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -32,7 +32,7 @@ return [
         \BeyondCode\SelfDiagnosis\Checks\LocalesAreInstalled::class => [
             'required_locales' => [
                 'en_US',
-                'en_US.utf8',
+                PHP_OS === 'Darwin' ? 'en_US.UTF-8' : 'en_US.utf8',
             ],
         ],
         \BeyondCode\SelfDiagnosis\Checks\MaintenanceModeNotEnabled::class,


### PR DESCRIPTION
Since the correct locale on macOS is `en_US.UTF-8` and not `en_US.utf8`, the default config should take that into account.