### PR TITLE
Update composer.json to allow Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "composer/semver": "^1.4",
         "geerlingguy/ping": "^1.1",
         "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
-        "vlucas/phpdotenv": "~2.5|~3.3"
+        "vlucas/phpdotenv": "~2.5|~3.3|^4.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",


### PR DESCRIPTION
After release 1.4 I still couldn't install this package on a Laravel 7 project.

It was due to Laravel requiring `vlucas/phpdotenv` in version 4 while, this package required versions `~2.5|~3.3`.

This PR updates that dependency.

While testing, I saw phpdotenv version 3.3 was still pulled, that was due to testbench requiring laravel/framework 5.8. Locally I updated the require-dev dependencies, and tests ran fine. (also needed to update phpunit to 8.5)

I opted for not updating require-dev dependencies in this PR as many changes were required and I don't know if it could break any other thing.

If you want I can send another PR (or add a commit to this one) with updated require-dev dependencies.
