### PR TITLE
[Laravel 7] fix dotenv 4 checks

### DIFF
--- a/src/Checks/ExampleEnvironmentVariablesAreSet.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreSet.php
@@ -29,6 +29,10 @@ class ExampleEnvironmentVariablesAreSet implements Check
      */
     public function check(array $config): bool
     {
+        if (method_exists(Dotenv::class, 'createImmutable')) {
+            return $this->checkForDotEnvV4();
+        }
+
         if (interface_exists(\Dotenv\Environment\FactoryInterface::class)) {
             $examples = Dotenv::create(base_path(), '.env.example');
             $actual = Dotenv::create(base_path(), '.env');
@@ -42,6 +46,22 @@ class ExampleEnvironmentVariablesAreSet implements Check
 
         $this->envVariables = Collection::make($examples->getEnvironmentVariableNames())
             ->diff($actual->getEnvironmentVariableNames());
+
+        return $this->envVariables->isEmpty();
+    }
+
+    /**
+     * Perform the verification of this check for DotEnv v4.
+     *
+     * @return bool
+     */
+    public function checkForDotEnvV4(): bool
+    {
+        $examples = Dotenv::createImmutable(base_path(), '.env.example');
+        $actual = Dotenv::createImmutable(base_path(), '.env');
+
+        $this->envVariables = Collection::make($examples->safeLoad())
+            ->diff($actual->safeLoad());
 
         return $this->envVariables->isEmpty();
     }

--- a/src/Checks/ExampleEnvironmentVariablesAreSet.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreSet.php
@@ -55,7 +55,7 @@ class ExampleEnvironmentVariablesAreSet implements Check
      *
      * @return bool
      */
-    public function checkForDotEnvV4(): bool
+    private function checkForDotEnvV4(): bool
     {
         $examples = Dotenv::createImmutable(base_path(), '.env.example');
         $actual = Dotenv::createImmutable(base_path(), '.env');

--- a/src/Checks/ExampleEnvironmentVariablesAreSet.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreSet.php
@@ -61,7 +61,8 @@ class ExampleEnvironmentVariablesAreSet implements Check
         $actual = Dotenv::createImmutable(base_path(), '.env');
 
         $this->envVariables = Collection::make($examples->safeLoad())
-            ->diff($actual->safeLoad());
+            ->diffKeys($actual->safeLoad())
+            ->keys();
 
         return $this->envVariables->isEmpty();
     }

--- a/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
@@ -61,7 +61,8 @@ class ExampleEnvironmentVariablesAreUpToDate implements Check
         $actual = Dotenv::createImmutable(base_path(), '.env');
 
         $this->envVariables = Collection::make($actual->safeLoad())
-            ->diff($examples->safeLoad());
+            ->diffKeys($examples->safeLoad())
+            ->keys();
 
         return $this->envVariables->isEmpty();
     }

--- a/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
@@ -55,7 +55,7 @@ class ExampleEnvironmentVariablesAreUpToDate implements Check
      *
      * @return bool
      */
-    public function checkForDotEnvV4(): bool
+    private function checkForDotEnvV4(): bool
     {
         $examples = Dotenv::createImmutable(base_path(), '.env.example');
         $actual = Dotenv::createImmutable(base_path(), '.env');

--- a/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreUpToDate.php
@@ -29,6 +29,10 @@ class ExampleEnvironmentVariablesAreUpToDate implements Check
      */
     public function check(array $config): bool
     {
+        if (method_exists(Dotenv::class, 'createImmutable')) {
+            return $this->checkForDotEnvV4();
+        }
+
         if (interface_exists(\Dotenv\Environment\FactoryInterface::class)) {
             $examples = Dotenv::create(base_path(), '.env.example');
             $actual = Dotenv::create(base_path(), '.env');
@@ -42,6 +46,22 @@ class ExampleEnvironmentVariablesAreUpToDate implements Check
 
         $this->envVariables = Collection::make($actual->getEnvironmentVariableNames())
             ->diff($examples->getEnvironmentVariableNames());
+
+        return $this->envVariables->isEmpty();
+    }
+
+    /**
+     * Perform the verification of this check for DotEnv v4.
+     *
+     * @return bool
+     */
+    public function checkForDotEnvV4(): bool
+    {
+        $examples = Dotenv::createImmutable(base_path(), '.env.example');
+        $actual = Dotenv::createImmutable(base_path(), '.env');
+
+        $this->envVariables = Collection::make($actual->safeLoad())
+            ->diff($examples->safeLoad());
 
         return $this->envVariables->isEmpty();
     }


### PR DESCRIPTION
After using the new version on a Laravel 7 app, DotEnv related checks failed due to changes on the DotEnv constructor and static constructors (`::create(...)`)

Reference: https://github.com/vlucas/phpdotenv/blob/v4.0.1/UPGRADING.md#v3-to-v4

This PR update these checks:

- `ExampleEnvironmentVariablesAreSet`
- `ExampleEnvironmentVariablesAreUpToDate`

To comply with the new DotEnv's version.

Note: I added a separated method for DotEnv 4 with a early return to avoid adding to many if branches in each class' `check` method.