### PR TITLE
Fix dotv5 - Laravel 8 and config cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "larapack/dd": "^1.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "~3.5|~3.8",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.0|^8.0",
         "predis/predis": "^1.1",
         "scrutinizer/ocular": "^1.5"
     },

--- a/src/Checks/ExampleEnvironmentVariablesAreSet.php
+++ b/src/Checks/ExampleEnvironmentVariablesAreSet.php
@@ -29,6 +29,9 @@ class ExampleEnvironmentVariablesAreSet implements Check
      */
     public function check(array $config): bool
     {
+        if (method_exists(Dotenv::class, 'createUnsafeImmutable')) {
+            return $this->checkForDotEnvV5();
+        }
         if (method_exists(Dotenv::class, 'createImmutable')) {
             return $this->checkForDotEnvV4();
         }
@@ -59,6 +62,23 @@ class ExampleEnvironmentVariablesAreSet implements Check
     {
         $examples = Dotenv::createImmutable(base_path(), '.env.example');
         $actual = Dotenv::createImmutable(base_path(), '.env');
+
+        $this->envVariables = Collection::make($examples->safeLoad())
+            ->diffKeys($actual->safeLoad())
+            ->keys();
+
+        return $this->envVariables->isEmpty();
+    }
+
+    /**
+     * Perform the verification of this check for DotEnv v5.
+     *
+     * @return bool
+     */
+    private function checkForDotEnvV5(): bool
+    {
+        $examples = Dotenv::createMutable(base_path(), '.env.example');
+        $actual = Dotenv::createMutable(base_path(), '.env');
 
         $this->envVariables = Collection::make($examples->safeLoad())
             ->diffKeys($actual->safeLoad())

--- a/tests/CorrectPhpVersionIsInstalledTest.php
+++ b/tests/CorrectPhpVersionIsInstalledTest.php
@@ -60,7 +60,7 @@ class CorrectPhpVersionIsInstalledTest extends TestCase
 
         $data = file_get_contents(__DIR__ . '/fixtures/composer.json');
 
-        $data = str_replace('"php": "^7.1.3",', '"php": "7.*",', $data);
+        $data = str_replace('"php": "^7.1.3",', '"php": "7.*|8.*",', $data);
 
         $fileSystemMock->shouldReceive('get')
             ->andReturn($data);


### PR DESCRIPTION
fix #103 

This PR fix `ExampleEnvironmentVariablesAreSet` for Laravel 8 (dotenv 5) when config is cache.


## Before fix 
```bash
➜ php artisan self-diagnosis
|-------------------------------------
| Common Checks
|-------------------------------------
Running check 1/12: App key is set...  ✔
Running check 2/12: The correct PHP version is installed...  ✔
Running check 3/12: The database can be accessed...  ✔
Running check 4/12: All directories have the correct permissions...  ✔
Running check 5/12: The environment file exists...  ✔
Running check 6/12: The example environment variables are set...  ✘
Running check 7/12: Required locales are installed...  ✔
Running check 8/12: Maintenance mode is not enabled...  ✔
Running check 9/12: The migrations are up to date...  ✔
Running check 10/12: The required PHP extensions are installed...  ✔
Running check 11/12: The storage directory is linked...  ✔
Running check 12/12: Meta robot - Noindex Nofollow check...  ✔

|-------------------------------------
| Environment Specific Checks (production)
|-------------------------------------
Running check 1/5: Composer dependencies (without dev) are up to date...  ✔
Running check 2/5: Configuration is cached...  ✔
Running check 3/5: Debug mode is not enabled...  ✔
Running check 4/5: Unwanted PHP extensions are disabled...  ✘
Running check 5/5: Routes are cached...  ✔

The following checks failed:
These environment variables are missing in your .env file, but are defined in your .env.example:
APP_NAME
APP_ENV
APP_KEY
APP_DEBUG
APP_URL
LOG_CHANNEL
LOG_LEVEL
DB_CONNECTION
DB_HOST
DB_PORT
DB_DATABASE
DB_USERNAME
DB_PASSWORD
BROADCAST_DRIVER
CACHE_DRIVER
QUEUE_CONNECTION
SESSION_DRIVER
SESSION_LIFETIME
MEMCACHED_HOST
REDIS_HOST
REDIS_PASSWORD
REDIS_PORT
MAIL_MAILER
MAIL_HOST
MAIL_PORT
MAIL_USERNAME
MAIL_PASSWORD
MAIL_ENCRYPTION
MAIL_FROM_ADDRESS
MAIL_FROM_NAME
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_DEFAULT_REGION
AWS_BUCKET
PUSHER_APP_ID
PUSHER_APP_KEY
PUSHER_APP_SECRET
PUSHER_APP_CLUSTER
MIX_PUSHER_APP_KEY
MIX_PUSHER_APP_CLUSTER

The following extensions are still enabled:
xdebug
```
## After fix
```bash
➜ php artisan self-diagnosis
|-------------------------------------
| Common Checks
|-------------------------------------
Running check 1/12: App key is set...  ✔
Running check 2/12: The correct PHP version is installed...  ✔
Running check 3/12: The database can be accessed...  ✔
Running check 4/12: All directories have the correct permissions...  ✔
Running check 5/12: The environment file exists...  ✔
Running check 6/12: The example environment variables are set...  ✔
Running check 7/12: Required locales are installed...  ✔
Running check 8/12: Maintenance mode is not enabled...  ✔
Running check 9/12: The migrations are up to date...  ✔
Running check 10/12: The required PHP extensions are installed...  ✔
Running check 11/12: The storage directory is linked...  ✔
Running check 12/12: Meta robot - Noindex Nofollow check...  ✔

|-------------------------------------
| Environment Specific Checks (production)
|-------------------------------------
Running check 1/5: Composer dependencies (without dev) are up to date...  ✔
Running check 2/5: Configuration is cached...  ✔
Running check 3/5: Debug mode is not enabled...  ✔
Running check 4/5: Unwanted PHP extensions are disabled...  ✘
Running check 5/5: Routes are cached...  ✔

The following checks failed:
The following extensions are still enabled:
xdebug
```