### PR TITLE
Handle inconsistent install output on composer versions below 2.4.5 w…

### DIFF
--- a/src/Checks/ComposerWithDevDependenciesIsUpToDate.php
+++ b/src/Checks/ComposerWithDevDependenciesIsUpToDate.php
@@ -43,7 +43,11 @@ class ComposerWithDevDependenciesIsUpToDate implements Check
 
         $this->output = $this->composer->installDryRun($additionalOptions);
 
-        return Str::contains($this->output, ['Nothing to install or update', 'Nothing to install, update or remove']);
+        return Str::contains($this->output, [
+            'Nothing to install or update',
+            'Nothing to install, update or remove',
+            'Package operations: 0 installs, 0 updates, 0 removals'
+        ]);
     }
 
     /**

--- a/src/Checks/ComposerWithoutDevDependenciesIsUpToDate.php
+++ b/src/Checks/ComposerWithoutDevDependenciesIsUpToDate.php
@@ -43,7 +43,11 @@ class ComposerWithoutDevDependenciesIsUpToDate implements Check
 
         $this->output = $this->composer->installDryRun('--no-dev ' . $additionalOptions);
 
-        return Str::contains($this->output, ['Nothing to install or update', 'Nothing to install, update or remove']);
+        return Str::contains($this->output, [
+            'Nothing to install or update',
+            'Nothing to install, update or remove',
+            'Package operations: 0 installs, 0 updates, 0 removals'
+        ]);
     }
 
     /**


### PR DESCRIPTION
When using aliases in composer, before https://github.com/composer/composer/pull/11159 was merged there would be a different output when there was any composer alias used compared to when there were none This was fixed in composer, and will probably be included in the next release. This PR adds backwards compatibility for when self-diagnosis is run with older composer versions.